### PR TITLE
Que una caída de servidor no rompa nada (y un segfault de regalo)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@
 
 ## geouy v0.2.9
 
+* Fix a crash in `load_geouy()`: when a zip layer failed to download, the
+  retry used `download.file(..., mode = "a")`, which segfaults and aborts the
+  R session when the server does not answer. The download is now attempted
+  once in `"wb"` mode and reports which layer and server failed.
+* Examples that rely on remote services now check the result of the download
+  before using it, so an unreachable server no longer turns into an error in
+  `R CMD check`.
 * Fix `tiles_geouy()`, which aborted on every call with a false "IDEuy Server
   out of service". The grid layers now carry administrative columns with
   legitimate NA values, so validating the download with `noNA()` always failed;

--- a/R/add_geom.R
+++ b/R/add_geom.R
@@ -16,7 +16,9 @@
 #' \donttest{
 #' pobre_x_dpto <- as.data.frame(cbind(nomdpto = c("ARTIGAS", "DURAZNO", "FLORIDA", "LAVALLEJA"),
 #'                Pobreza = c(0.26, 0.27, 0.07, 0.10)))
-#' pobre_x_dpto_geo <- add_geom(data = pobre_x_dpto, unit = "Deptos", variable = "nomdpto")
+#' pobre_x_dpto_geo <- try(add_geom(data = pobre_x_dpto, unit = "Deptos",
+#'                                  variable = "nomdpto"), silent = TRUE)
+#' if (!inherits(pobre_x_dpto_geo, "try-error")) pobre_x_dpto_geo
 #' }
 
 add_geom <- function(data, unit, variable, crs = 32721){

--- a/R/load_geouy.R
+++ b/R/load_geouy.R
@@ -13,7 +13,8 @@
 #' @export
 #' @examples
 #'\donttest{
-#' secc <- load_geouy(c = "Secciones")
+#' secc <- try(load_geouy(c = "Secciones"), silent = TRUE)
+#' if (!inherits(secc, "try-error")) head(secc)
 #'}
 
 load_geouy <- function(c, crs = 32721, folder = tempdir()){
@@ -34,11 +35,20 @@ load_geouy <- function(c, crs = 32721, folder = tempdir()){
     f = glue::glue("{folder}/{x$capa}.zip")
     if (!file.exists(f)) {
       message(glue::glue("Intentando descargar {x$capa}..."))
-      tryCatch({
-        utils::download.file(x$url, f, mode = "wb", method = "libcurl", extra = '--no-check-certificate')
-      }, error = function(e) {
-        utils::download.file(x$url, f, mode = "a", method = "libcurl", extra = '--no-check-certificate')
-      })
+      # El reintento en modo "a" (append) sobre el mismo archivo no aportaba
+      # nada -pedia otra vez la misma URL- y ademas es peligroso: cuando el
+      # servidor no responde, download.file() con mode = "a" aborta R con un
+      # segfault, que ningun try() del usuario puede recuperar. Con mode = "wb"
+      # el fallo es un error normal, que si se puede manejar.
+      descarga <- tryCatch(
+        utils::download.file(x$url, f, mode = "wb", method = "libcurl"),
+        error = function(e) e)
+      if (inherits(descarga, "error")) {
+        servidor <- sub("^(https?://[^/]+).*", "\\1", x$url)
+        stop(glue::glue("Could not download the layer '{c}' from {servidor}. ",
+                        "The server may be down or the layer may have changed.\n",
+                        "Details: {conditionMessage(descarga)}"), call. = FALSE)
+      }
     }
     invisible(try(utils::unzip(f, exdir = folder)))
       #archive_extract(archive.path = f, dest.path = )))

--- a/R/plot_geouy.R
+++ b/R/plot_geouy.R
@@ -16,8 +16,8 @@
 #'
 #' @examples
 #' \donttest{
-#' secc <- load_geouy("Secciones")
-#' plot_geouy(x = secc, col = "pob_tot_23")
+#' secc <- try(load_geouy("Secciones"), silent = TRUE)
+#' if (!inherits(secc, "try-error")) plot_geouy(x = secc, col = "pob_tot_23")
 #' }
 #' 
 

--- a/R/tiles_geouy.R
+++ b/R/tiles_geouy.R
@@ -23,8 +23,9 @@
 #'\donttest{
 #' x <- data.frame(x = 577968, y = 6147753, id = 1)
 #' x <- sf::st_as_sf(x, coords = c("x", "y"), crs = 32721)
-#' x_tiles <- tiles_geouy(x, urban = TRUE)
-#'} 
+#' x_tiles <- try(tiles_geouy(x, urban = TRUE), silent = TRUE)
+#' if (!inherits(x_tiles, "try-error")) x_tiles
+#'}
 
 tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = FALSE){
   # checks ----

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,8 @@
 #' @export
 #' @examples
 #'\donttest{
-#' is.uy4326(load_geouy("Peajes"))
+#' x <- try(load_geouy("Peajes"), silent = TRUE)
+#' if (!inherits(x, "try-error")) is.uy4326(x)
 #'}
 
 is.uy4326 <- function(x){
@@ -32,7 +33,8 @@ is.uy4326 <- function(x){
 #' @export
 #' @examples
 #'\donttest{
-#' is.uy32721(load_geouy("Uruguay"))
+#' x <- try(load_geouy("Uruguay"), silent = TRUE)
+#' if (!inherits(x, "try-error")) is.uy32721(x)
 #'}
 
 is.uy32721 <- function(x){
@@ -58,7 +60,8 @@ is.uy32721 <- function(x){
 #' @export
 #' @examples
 #'\donttest{
-#' is.uy5381(load_geouy("CCZ"))
+#' x <- try(load_geouy("CCZ"), silent = TRUE)
+#' if (!inherits(x, "try-error")) is.uy5381(x)
 #'}
 
 is.uy5381 <- function(x){
@@ -84,7 +87,8 @@ is.uy5381 <- function(x){
 #' @export
 #' @examples
 #'\donttest{
-#' is.uy5382(load_geouy("Uruguay"))
+#' x <- try(load_geouy("Uruguay"), silent = TRUE)
+#' if (!inherits(x, "try-error")) is.uy5382(x)
 #'}
 
 is.uy5382 <- function(x){

--- a/R/where_uy.R
+++ b/R/where_uy.R
@@ -9,7 +9,8 @@
 #' @export
 #' @examples
 #'\donttest{
-#' x <- where_uy(c = "Localidades pg", d = "cod", e = c(1020, 2020))
+#' x <- try(where_uy(c = "Localidades pg", d = "cod", e = c(1020, 2020)), silent = TRUE)
+#' if (!inherits(x, "try-error")) x
 #'}
 
 where_uy <- function(c = "Localidades pg", d = "cod", e, crs = 32721) {

--- a/R/which_uy.R
+++ b/R/which_uy.R
@@ -8,8 +8,8 @@
 #' @export
 #' @examples
 #'\donttest{
-#' x <- load_geouy("Peajes")
-#' x1 <- which_uy(x, c = "Deptos")
+#' x <- try(load_geouy("Peajes"), silent = TRUE)
+#' if (!inherits(x, "try-error")) x1 <- which_uy(x, c = "Deptos")
 #'}
 
 which_uy <- function(x, c = c("Localidades pg", "Departamentos"), d = c("cod", "name")){

--- a/man/add_geom.Rd
+++ b/man/add_geom.Rd
@@ -29,7 +29,9 @@ Aviso: El script no es un producto oficial de INE.
 \donttest{
 pobre_x_dpto <- as.data.frame(cbind(nomdpto = c("ARTIGAS", "DURAZNO", "FLORIDA", "LAVALLEJA"),
                Pobreza = c(0.26, 0.27, 0.07, 0.10)))
-pobre_x_dpto_geo <- add_geom(data = pobre_x_dpto, unit = "Deptos", variable = "nomdpto")
+pobre_x_dpto_geo <- try(add_geom(data = pobre_x_dpto, unit = "Deptos",
+                                 variable = "nomdpto"), silent = TRUE)
+if (!inherits(pobre_x_dpto_geo, "try-error")) pobre_x_dpto_geo
 }
 }
 \seealso{

--- a/man/is.uy32721.Rd
+++ b/man/is.uy32721.Rd
@@ -17,7 +17,8 @@ This function test if an 'sf' object match with Uruguay at crs = 32721.
 }
 \examples{
 \donttest{
-is.uy32721(load_geouy("Uruguay"))
+x <- try(load_geouy("Uruguay"), silent = TRUE)
+if (!inherits(x, "try-error")) is.uy32721(x)
 }
 }
 \seealso{

--- a/man/is.uy4326.Rd
+++ b/man/is.uy4326.Rd
@@ -17,7 +17,8 @@ This function test if an 'sf' object match with Uruguay at crs = 4326.
 }
 \examples{
 \donttest{
-is.uy4326(load_geouy("Peajes"))
+x <- try(load_geouy("Peajes"), silent = TRUE)
+if (!inherits(x, "try-error")) is.uy4326(x)
 }
 }
 \seealso{

--- a/man/is.uy5381.Rd
+++ b/man/is.uy5381.Rd
@@ -17,7 +17,8 @@ This function test if an 'sf' object match with Uruguay at crs = 5381.
 }
 \examples{
 \donttest{
-is.uy5381(load_geouy("CCZ"))
+x <- try(load_geouy("CCZ"), silent = TRUE)
+if (!inherits(x, "try-error")) is.uy5381(x)
 }
 }
 \seealso{

--- a/man/is.uy5382.Rd
+++ b/man/is.uy5382.Rd
@@ -17,7 +17,8 @@ This function test if an 'sf' object match with Uruguay at crs = 5382.
 }
 \examples{
 \donttest{
-is.uy5382(load_geouy("Uruguay"))
+x <- try(load_geouy("Uruguay"), silent = TRUE)
+if (!inherits(x, "try-error")) is.uy5382(x)
 }
 }
 \seealso{

--- a/man/load_geouy.Rd
+++ b/man/load_geouy.Rd
@@ -21,7 +21,8 @@ This function allows to take oficial uruguayan geometries, as object "sf", from 
 }
 \examples{
 \donttest{
-secc <- load_geouy(c = "Secciones")
+secc <- try(load_geouy(c = "Secciones"), silent = TRUE)
+if (!inherits(secc, "try-error")) head(secc)
 }
 }
 \seealso{

--- a/man/plot_geouy.Rd
+++ b/man/plot_geouy.Rd
@@ -27,8 +27,8 @@ This function allows you to set ggplot2 theme in our suggested format.
 }
 \examples{
 \donttest{
-secc <- load_geouy("Secciones")
-plot_geouy(x = secc, col = "pob_tot_23")
+secc <- try(load_geouy("Secciones"), silent = TRUE)
+if (!inherits(secc, "try-error")) plot_geouy(x = secc, col = "pob_tot_23")
 }
 
 }

--- a/man/tiles_geouy.Rd
+++ b/man/tiles_geouy.Rd
@@ -27,8 +27,9 @@ This function allows to Download .jpg or .tif files from the IDEuy tiles reposit
 \donttest{
 x <- data.frame(x = 577968, y = 6147753, id = 1)
 x <- sf::st_as_sf(x, coords = c("x", "y"), crs = 32721)
-x_tiles <- tiles_geouy(x, urban = TRUE)
-} 
+x_tiles <- try(tiles_geouy(x, urban = TRUE), silent = TRUE)
+if (!inherits(x_tiles, "try-error")) x_tiles
+}
 }
 \seealso{
 Other service:

--- a/man/where_uy.Rd
+++ b/man/where_uy.Rd
@@ -23,7 +23,8 @@ This function return an 'sf' object with the geometry of the consult id or group
 }
 \examples{
 \donttest{
-x <- where_uy(c = "Localidades pg", d = "cod", e = c(1020, 2020))
+x <- try(where_uy(c = "Localidades pg", d = "cod", e = c(1020, 2020)), silent = TRUE)
+if (!inherits(x, "try-error")) x
 }
 }
 \seealso{

--- a/man/which_uy.Rd
+++ b/man/which_uy.Rd
@@ -21,8 +21,8 @@ This function allows to add to an 'sf' object its spatial coincidence with one o
 }
 \examples{
 \donttest{
-x <- load_geouy("Peajes")
-x1 <- which_uy(x, c = "Deptos")
+x <- try(load_geouy("Peajes"), silent = TRUE)
+if (!inherits(x, "try-error")) x1 <- which_uy(x, c = "Deptos")
 }
 }
 \seealso{


### PR DESCRIPTION
Esto empezó como lo que habíamos hablado —que los ejemplos no hagan fallar el check cuando un servicio no responde— y en el camino apareció algo bastante más serio, así que arranco por ahí.

### 1. `load_geouy()` podía abortar la sesión de R

Cuando fallaba la descarga de una capa en formato **zip**, el código reintentaba la misma URL así:

```r
tryCatch({
  utils::download.file(x$url, f, mode = "wb", method = "libcurl", extra = '--no-check-certificate')
}, error = function(e) {
  utils::download.file(x$url, f, mode = "a", method = "libcurl", extra = '--no-check-certificate')
})
```

El reintento pedía exactamente lo mismo que acababa de fallar, sólo que en modo *append*, así que no podía funcionar. Pero el problema no es que no funcione: **con el servidor sin responder, `download.file()` en modo `"a"` termina en un segfault y R aborta**. Se reproduce sin el paquete de por medio, apuntando a cualquier servidor que no conteste:

```r
download.file(url, destino, mode = "a",  method = "libcurl")   # *** caught segfault ***
download.file(url, destino, mode = "wb", method = "libcurl")   # error normal, capturable
```

Lo importante es que **de un segfault no se vuelve con `try()`**: a quien esté usando el paquete se le cae la sesión entera con todo lo que tenga cargado. Le pasa a cualquiera que pida «Deptos», «Municipios» o cualquier otra capa zip justo cuando el servidor está caído. Y en un check de CRAN, un segfault es fallo total.

Ahora se intenta la descarga una sola vez en modo `"wb"` y, si falla, se corta con un mensaje que dice qué capa y qué servidor fallaron:

```
Could not download the layer 'Deptos' from https://mapas.ide.uy.
The server may be down or the layer may have changed.
Details: ...
```

De paso saqué el `extra = '--no-check-certificate'`. Con el método libcurl ese parámetro nunca se aplica —sólo tiene efecto con wget o curl—, así que era código muerto; y como encima sugiere una práctica que no estábamos haciendo, mejor que no esté (a `ech` le costó un archivo en CRAN en 2020 justamente por saltear verificación de certificados).

### 2. Los ejemplos ya no rompen el check si un servicio no contesta

Los diez ejemplos de la ayuda que dependen de red pasan a comprobar el resultado de la descarga antes de usarlo:

```r
uy <- try(load_geouy("Uruguay"), silent = TRUE)
if (!inherits(uy, "try-error")) is.uy32721(uy)
```

Si el servicio responde, hacen exactamente lo mismo que antes. Si no responde, no hacen nada y el check sigue limpio. Vale recordar que `\donttest{}` no protege: CRAN corre esos ejemplos en sus chequeos adicionales, que fue de donde salió el archivo de 2025.

### Cómo lo verifiqué

Simulé los servidores caídos con un proxy apuntando a un puerto cerrado. Eso reproduce el caso real —hay internet, pero ningún servicio contesta: de hecho `curl::has_internet()` sigue devolviendo `TRUE`— y permite correr los ejemplos uno por uno en ese escenario.

| | master | con estos cambios |
|---|---|---|
| Servidores caídos, los 10 ejemplos | 9 ERROR y 1 **aborto de R** | **los 10 sin error** |
| Servidores arriba, `R CMD check --as-cran` | 0E / 0W / 3 NOTEs | 0E / 0W / 3 NOTEs, `--run-donttest` OK |

Vale la pena el detalle: **con los servidores arriba, las dos versiones dan idéntico resultado**. El segfault sólo aparece si uno se pone a probar el escenario en que el servicio no contesta, que es justamente el que nos viene mordiendo.

### Qué queda del issue #3

Los tests todavía tendrían que llevar `skip_if_offline()` donde corresponda, pero ese archivo va por otro lado: `.Rbuildignore` excluye `tests/` desde siempre, así que no viajan en el tarball ni se corren en CI, y además quedaron desactualizados respecto del Censo 2023. Lo dejo para tratarlo aparte y no mezclar.

Atiende #3.
