### PR TITLE
Limpiezas del DESCRIPTION: C++11 y las URLs que redirigen

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Maintainer: Richard Detomasi <richard.detomasi@gmail.com>
 Description: The toolbox have functions to load and process geographic
     information for Uruguay.  And extra-function to get address
     coordinates and orthophotos through the uruguayan 'IDE' API
-    <https://www.gub.uy/infraestructura-datos-espaciales/tramites-y-servicios/servicios/sistema-unico-direcciones-geograficas>.
+    <https://www.gub.uy/infraestructura-datos-espaciales/tramites-y-servicios/servicios/servicio-direcciones-geograficas>.
 License: GPL-3
 BugReports: https://github.com/RichDeto/geouy/issues
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,5 @@ Encoding: UTF-8
 Language: en-US
 LazyData: TRUE
 SystemRequirements: 'unrar' (Linux/macOS) or '7-Zip' (Windows) to work
-    with '.rar' files, C++11, GDAL (>= 2.0.1), GEOS (>= 3.8.0), PROJ (>=
-    6.2.1)
+    with '.rar' files, GDAL (>= 2.0.1), GEOS (>= 3.8.0), PROJ (>= 6.2.1)
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,7 +91,7 @@
 ## geouy v0.1.9 (2020-03-20)
 
 * Update test with CRS structure for sf 0.9 version
-* Limits in geocode_geouy(), you must be part of uruguayan public organism and  fill this (forms)[https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/formularios-alta-consumo-servicios-pdi] if your organism is not yet vinculated.
+* Limits in geocode_geouy(), you must be part of uruguayan public organism and  fill this (forms)[https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/formularios-publicacion-consumo-servicios-pdi] if your organism is not yet vinculated.
 
 
 ## geouy v0.1.8 (2020-03-17)

--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ Two datasets to use as `geofacet` grid dataset for departments of Uruguay and ne
 ## History
 
 This package arises from the conjugation of own ideas with an eye on the region. It started as a part of the package where I work with @calcita at [ech](https://github.com/calcita/ech), and some geospatial service packages in the region mainly: 
-[geobr](https://github.com/ipeaGIT/geobr) and 
+[geobr](https://github.com/ipea/geobr) and 
 [chilemapas](https://github.com/pachadotdev/chilemapas)
 
-This walk on the shoulders of giants, allows this package focused on this small country (my beautiful Uruguay), to have its own particularities although it tries to fit especially to [geobr](https://github.com/ipeaGIT/geobr) in its structure and with a view to complementing [ech](https://github.com/calcita/ech).
+This walk on the shoulders of giants, allows this package focused on this small country (my beautiful Uruguay), to have its own particularities although it tries to fit especially to [geobr](https://github.com/ipea/geobr) in its structure and with a view to complementing [ech](https://github.com/calcita/ech).
 
 ## Community contributions [es](https://github.com/RichDeto/geouy/issues/1)
 

--- a/vignettes/geouy.Rmd
+++ b/vignettes/geouy.Rmd
@@ -72,7 +72,7 @@ nuevas <- data.frame(cbind(dpto = c("Montevideo", "Salto"),
 nuevas_geo <- geocode_ide_uy(nuevas)
 ```	
 	
-NOTA: Limite en geocode_ide_uy(), tienes que ser parte de un organismo público uruguayo o deberas completar el siguiente [formulario](https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/formularios-alta-consumo-servicios-pdi) para habilitar el funcionamiento de su API.
+NOTA: Limite en geocode_ide_uy(), tienes que ser parte de un organismo público uruguayo o deberas completar el siguiente [formulario](https://www.gub.uy/agencia-gobierno-electronico-sociedad-informacion-conocimiento/comunicacion/publicaciones/formularios-publicacion-consumo-servicios-pdi) para habilitar el funcionamiento de su API.
 
 ### Asignar codigos y nombres de otras geometrías
 


### PR DESCRIPTION
Las dos cosas del issue #8, que son cortas pero dejan el check sin NOTEs propios.

### C++11 en `SystemRequirements`

Las versiones actuales de R responden a esa declaración con un NOTE en el paso *checking whether package can be installed*:

```
SystemRequirements specified C++11: support has been removed
```

Aparece en Windows y en las dos Ubuntu. Además quedó de otra época: se había agregado en 2020 por un requisito de `sf`, y el paquete no tiene código compilado propio (`NeedsCompilation: no`), así que hoy no corresponde declararlo. El resto de los requisitos —unrar, GDAL, GEOS y PROJ— queda igual.

### Tres URLs que responden 301

El check las marca como «possibly invalid URLs». Las tres siguen apuntando a contenido que existe, solo que cambió de dirección:

| Dónde | Cambio |
|---|---|
| DESCRIPTION | el servicio de direcciones de IDE pasó de `sistema-unico-direcciones-geograficas` a `servicio-direcciones-geograficas` |
| README | el repositorio de geobr se mudó de `ipeaGIT` a `ipea` (aparece dos veces) |
| Viñeta | el formulario de AGESIC pasó de `formularios-alta-...` a `formularios-publicacion-...` |

Antes de tocar nada verifiqué las seis direcciones: cada una de las viejas redirige exactamente a la nueva, y las nuevas responden 200 sin más saltos.

Apareció además una cuarta ocurrencia que el check no reporta: la URL del formulario estaba también en una entrada del NEWS de 2020. La actualicé para no dejar el enlace roto, sin tocar el texto de la entrada.

### Cómo queda el check

Con esto, el `R CMD check --as-cran` no deja ningún NOTE atribuible al paquete. Quedan tres, los tres ajenos:

- «New submission / Package was archived on CRAN», que se resuelve solo cuando el paquete vuelva a publicarse;
- un directorio oculto de configuración de mi máquina, que no existe en un clon limpio;
- y la falta del binario `tidy` para validar el HTML del manual, que es de mi entorno.

Cierra #8.
