### PR TITLE
Que un servicio caído se entienda, y que nunca devuelva la capa equivocada

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,21 @@
 
 ## geouy v0.2.9
 
+* Fix `load_geouy()` returning a different layer than the one requested. After
+  downloading, the code picked the most recent `.shp` in the whole folder,
+  which defaults to `tempdir()` and is shared between calls. `unzip()` does not
+  raise an error when the file is not a zip -it warns and returns `NULL`, and
+  the warning was swallowed by a `try()`- so a server answering with an error
+  page left the previous layer's shapefile as the newest one, and it was read
+  and returned with no warning at all. Only the files `unzip()` reports as
+  extracted are considered now, and the unusable download is removed so a
+  retry can succeed.
+* `load_geouy()` now reports which layer and which server failed for every
+  remote read, not only for the zip downloads. Layers read over WFS used to
+  surface the raw GDAL error, which names neither.
+* The example of `which_uy()` now shields both downloads. It covered only the
+  first one, and the two layers come from different servers, so one of them
+  being unreachable was enough to turn `R CMD check` into an ERROR.
 * Fix a crash in `load_geouy()`: when a zip layer failed to download, the
   retry used `download.file(..., mode = "a")`, which segfaults and aborts the
   R session when the server does not answer. The download is now attempted

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,15 @@
 * `load_geouy()` now reports which layer and which server failed for every
   remote read, not only for the zip downloads. Layers read over WFS used to
   surface the raw GDAL error, which names neither.
+* Failures of `load_geouy()` now carry the reason the server or the client
+  actually reported. GDAL names the cause in a warning -"SSL certificate
+  problem: unable to get local issuer certificate", "Could not resolve host"-
+  and then raises a generic error that does not, so the message kept only the
+  generic half. The warnings are now collected and added to the details without
+  being muffled, so a read that still succeeds does not lose them. When a cause
+  is known the message no longer guesses that the server may be down, which had
+  it contradicting its own details.
+
 * The example of `which_uy()` now shields both downloads. It covered only the
   first one, and the two layers come from different servers, so one of them
   being unreachable was enough to turn `R CMD check` into an ERROR.

--- a/R/load_geouy.R
+++ b/R/load_geouy.R
@@ -3,13 +3,16 @@
 # estaba pidiendo ni a que servidor, que es justo lo que hace falta para saber
 # si el problema es de uno o es ajeno. Estas dos funciones lo traducen a un
 # mensaje que si lo dice, y dejan el original al final por si el motivo era otro.
-falla_de_servicio <- function(capa, url, accion, detalle) {
+falla_de_servicio <- function(capa, url, accion, detalle = NULL,
+                              causa = "The server may be down or the layer may have changed.") {
   # El prefijo "WFS:" que GDAL necesita en la URL no es parte del servidor.
   servidor <- sub("^WFS:", "", url)
   servidor <- sub("^(https?://[^/?#]+).*", "\\1", servidor)
-  stop(glue::glue("Could not {accion} the layer '{capa}' from {servidor}. ",
-                  "The server may be down or the layer may have changed.\n",
-                  "Details: {detalle}"), call. = FALSE)
+  mensaje <- glue::glue("Could not {accion} the layer '{capa}' from {servidor}. {causa}")
+  # El error original va al final, pero solo cuando lo hay: si el fallo lo
+  # detecto el paquete, la causa ya esta dicha y repetirla no aporta.
+  if (!is.null(detalle)) mensaje <- glue::glue("{mensaje}\nDetails: {detalle}")
+  stop(mensaje, call. = FALSE)
 }
 
 descarga_o_falla <- function(expr, capa, url, accion = "read") {
@@ -30,7 +33,6 @@ descarga_o_falla <- function(expr, capa, url, accion = "read") {
 #' @importFrom sf st_read st_transform
 #' @importFrom glue glue
 #' @importFrom utils download.file unzip
-#' @importFrom fs dir_ls
 #' @keywords IDE MIDES INE
 #' @return sf object with the requested geometries 
 #' @export
@@ -67,14 +69,29 @@ load_geouy <- function(c, crs = 32721, folder = tempdir()){
       descarga_o_falla(utils::download.file(x$url, f, mode = "wb", method = "libcurl"),
                        c, x$url, accion = "download")
     }
-    invisible(try(utils::unzip(f, exdir = folder)))
-      #archive_extract(archive.path = f, dest.path = )))
-    archivo <- fs::dir_ls(folder, regexp = "\\.shp$")
+    # Hay que mirar lo que el unzip extrajo, y no barrer la carpeta entera. Si
+    # lo que se bajo no era un zip -por ejemplo, una pagina de error servida con
+    # codigo 200-, unzip() no da error: avisa con un warning y devuelve NULL.
+    # El barrido entonces encontraba el shapefile de OTRA capa descargada antes
+    # en la misma carpeta, que por omision es tempdir() y se comparte entre
+    # llamadas, y load_geouy() devolvia esos datos como si fueran los pedidos,
+    # sin avisar nada.
+    extraidos <- descarga_o_falla(utils::unzip(f, exdir = folder),
+                                  c, x$url, accion = "unzip")
+    archivo <- extraidos[grepl("\\.shp$", extraidos, ignore.case = TRUE)]
+    if (length(archivo) == 0) {
+      # El archivo que no sirve se borra: si queda, la comprobacion de mas
+      # arriba saltea la descarga y todas las llamadas siguientes fallan igual.
+      unlink(f)
+      falla_de_servicio(c, x$url, "unzip",
+                        causa = "The server answered, but not with a zip containing a shapefile.")
+    }
     archivo <- archivo[which.max(file.info(archivo)$mtime)]
     if(!enco == "UTF-8"){
-      a <- sf::st_read(archivo, crs = x$crs, options = glue::glue("ENCODING=", enco))
+      a <- descarga_o_falla(
+        sf::st_read(archivo, crs = x$crs, options = glue::glue("ENCODING=", enco)), c, x$url)
     } else {
-      a <- sf::st_read(archivo, crs = x$crs)
+      a <- descarga_o_falla(sf::st_read(archivo, crs = x$crs), c, x$url)
     }
   } else {
     if(!enco == "UTF-8"){

--- a/R/load_geouy.R
+++ b/R/load_geouy.R
@@ -8,7 +8,11 @@ falla_de_servicio <- function(capa, url, accion, detalle = NULL,
   # El prefijo "WFS:" que GDAL necesita en la URL no es parte del servidor.
   servidor <- sub("^WFS:", "", url)
   servidor <- sub("^(https?://[^/?#]+).*", "\\1", servidor)
-  mensaje <- glue::glue("Could not {accion} the layer '{capa}' from {servidor}. {causa}")
+  mensaje <- glue::glue("Could not {accion} the layer '{capa}' from {servidor}.")
+  # La especulacion sirve cuando no hay nada mejor, pero estorba cuando si lo
+  # hay: quien la pasa en NULL es porque ya tiene la causa real y no quiere que
+  # el mensaje diga "puede estar caido" arriba de un detalle que dice otra cosa.
+  if (!is.null(causa)) mensaje <- glue::glue("{mensaje} {causa}")
   # El error original va al final, pero solo cuando lo hay: si el fallo lo
   # detecto el paquete, la causa ya esta dicha y repetirla no aporta.
   if (!is.null(detalle)) mensaje <- glue::glue("{mensaje}\nDetails: {detalle}")
@@ -16,12 +20,54 @@ falla_de_servicio <- function(capa, url, accion, detalle = NULL,
 }
 
 descarga_o_falla <- function(expr, capa, url, accion = "read") {
+  # GDAL y download.file suelen decir la causa real en un warning -"SSL
+  # certificate problem: unable to get local issuer certificate", "Timeout of N
+  # seconds was reached"- y recien despues tirar un error generico que no la
+  # menciona: "Cannot open ...; Check connection parameters". Quedarse solo con
+  # el error deja al usuario buscando un servidor caido cuando el problema
+  # puede ser, por ejemplo, que a ese servidor le falta la cadena de
+  # certificados. Por eso los avisos se copian y se suman al detalle.
+  avisos <- character()
   # expr llega sin evaluar y se fuerza aca adentro, de modo que el fallo ocurra
   # dentro del tryCatch. Se atrapan errores y no warnings: los handlers de
   # tryCatch son de salida, asi que un warning recuperable de GDAL abortaria la
-  # lectura y perderia un objeto valido.
-  tryCatch(force(expr),
-           error = function(e) falla_de_servicio(capa, url, accion, conditionMessage(e)))
+  # lectura y perderia un objeto valido. withCallingHandlers no tiene ese
+  # problema, y aca ademas no se llama a invokeRestart("muffleWarning"): el
+  # aviso se copia y sigue su camino, para que la lectura que igual funciona no
+  # pierda los avisos que el usuario tendria que ver.
+  tryCatch(
+    withCallingHandlers(force(expr),
+                        warning = function(w) avisos <<- c(avisos, conditionMessage(w))),
+    error = function(e) {
+      original <- conditionMessage(e)
+      # Con options(warn = 2) el aviso ya viene adentro del error, y GDAL a
+      # veces repite el suyo palabra por palabra: se descarta lo que ya este
+      # dicho. La comparacion es literal a proposito, porque los mensajes traen
+      # rutas y comillas que como expresion regular no significarian lo mismo.
+      avisos <- unique(avisos)
+      avisos <- avisos[!vapply(avisos, grepl, logical(1), x = original, fixed = TRUE)]
+      # Un fallo puede venir detras de cientos de avisos distintos, y volcarlos
+      # todos convierte el error en algo que nadie lee. Con los primeros alcanza
+      # para saber que paso; el resto se cuenta.
+      # Un fallo puede venir detras de muchos avisos distintos, y volcarlos todos
+      # convierte el error en algo que nadie lee; ademas stop() corta el mensaje
+      # a 8190 caracteres, asi que de nada sirve pasarse. En los fallos reales
+      # medidos -certificado, capa inexistente, host que no resuelve- GDAL emite
+      # uno solo, de modo que este tope casi nunca entra en juego.
+      tope <- 5L
+      if (length(avisos) > tope) {
+        avisos <- c(avisos[seq_len(tope)],
+                    glue::glue("... and {length(avisos) - tope} more warnings"))
+      }
+      detalle <- paste(c(original, avisos), collapse = "\n")
+      # Si hay aviso, hay causa dicha, y la frase generica sobra: pasarla igual
+      # deja el mensaje contradiciendose solo -"el servidor puede estar caido"
+      # arriba de "SSL certificate problem"-. La decision es por si hay aviso o
+      # no, no por lo que el aviso diga: los textos cambian entre versiones de
+      # GDAL y entre idiomas, y no se puede colgar de ahi el comportamiento.
+      if (length(avisos)) falla_de_servicio(capa, url, accion, detalle, causa = NULL)
+      else falla_de_servicio(capa, url, accion, detalle)
+    })
 }
 
 #' This function allows to take oficial uruguayan geometries, as object "sf", from various servers.

--- a/R/load_geouy.R
+++ b/R/load_geouy.R
@@ -1,3 +1,26 @@
+# Cuando un servicio no responde, lo que sube es el error crudo de GDAL o el de
+# download.file: "Cannot open data source" y poco mas. No dice que capa se
+# estaba pidiendo ni a que servidor, que es justo lo que hace falta para saber
+# si el problema es de uno o es ajeno. Estas dos funciones lo traducen a un
+# mensaje que si lo dice, y dejan el original al final por si el motivo era otro.
+falla_de_servicio <- function(capa, url, accion, detalle) {
+  # El prefijo "WFS:" que GDAL necesita en la URL no es parte del servidor.
+  servidor <- sub("^WFS:", "", url)
+  servidor <- sub("^(https?://[^/?#]+).*", "\\1", servidor)
+  stop(glue::glue("Could not {accion} the layer '{capa}' from {servidor}. ",
+                  "The server may be down or the layer may have changed.\n",
+                  "Details: {detalle}"), call. = FALSE)
+}
+
+descarga_o_falla <- function(expr, capa, url, accion = "read") {
+  # expr llega sin evaluar y se fuerza aca adentro, de modo que el fallo ocurra
+  # dentro del tryCatch. Se atrapan errores y no warnings: los handlers de
+  # tryCatch son de salida, asi que un warning recuperable de GDAL abortaria la
+  # lectura y perderia un objeto valido.
+  tryCatch(force(expr),
+           error = function(e) falla_de_servicio(capa, url, accion, conditionMessage(e)))
+}
+
 #' This function allows to take oficial uruguayan geometries, as object "sf", from various servers.
 #' @family service
 #' @param c Define the geometries to download: may be: "Departamentos", "Secciones", "Zonas", etc. View(metadata) for details.
@@ -25,7 +48,8 @@ load_geouy <- function(c, crs = 32721, folder = tempdir()){
   x <- x[x$capa == c,]
   enco <- x$enc
   if (x$repositor %in% "SGM") {
-    a <- sf::st_read("WFS:http://geoservicios.sgm.gub.uy/wfsPCN1000.cgi?",x$url, crs = x$crs)
+    wfs_sgm <- "WFS:http://geoservicios.sgm.gub.uy/wfsPCN1000.cgi?"
+    a <- descarga_o_falla(sf::st_read(wfs_sgm, x$url, crs = x$crs), c, wfs_sgm)
   } else if (x$formato %in% c("zip", "zip a")) {
     if (!is.character(folder) | length(folder) != 1) {
       stop(glue::glue("You must enter a valid directory..."))
@@ -40,15 +64,8 @@ load_geouy <- function(c, crs = 32721, folder = tempdir()){
       # servidor no responde, download.file() con mode = "a" aborta R con un
       # segfault, que ningun try() del usuario puede recuperar. Con mode = "wb"
       # el fallo es un error normal, que si se puede manejar.
-      descarga <- tryCatch(
-        utils::download.file(x$url, f, mode = "wb", method = "libcurl"),
-        error = function(e) e)
-      if (inherits(descarga, "error")) {
-        servidor <- sub("^(https?://[^/]+).*", "\\1", x$url)
-        stop(glue::glue("Could not download the layer '{c}' from {servidor}. ",
-                        "The server may be down or the layer may have changed.\n",
-                        "Details: {conditionMessage(descarga)}"), call. = FALSE)
-      }
+      descarga_o_falla(utils::download.file(x$url, f, mode = "wb", method = "libcurl"),
+                       c, x$url, accion = "download")
     }
     invisible(try(utils::unzip(f, exdir = folder)))
       #archive_extract(archive.path = f, dest.path = )))
@@ -61,9 +78,10 @@ load_geouy <- function(c, crs = 32721, folder = tempdir()){
     }
   } else {
     if(!enco == "UTF-8"){
-      a <- sf::st_read(x$url, crs = x$crs, options = glue::glue("ENCODING=", enco))
+      a <- descarga_o_falla(
+        sf::st_read(x$url, crs = x$crs, options = glue::glue("ENCODING=", enco)), c, x$url)
     } else {
-      a <- sf::st_read(x$url, crs = x$crs) 
+      a <- descarga_o_falla(sf::st_read(x$url, crs = x$crs), c, x$url)
     }
   }
   a <- a %>% sf::st_transform(crs)

--- a/R/which_uy.R
+++ b/R/which_uy.R
@@ -8,8 +8,12 @@
 #' @export
 #' @examples
 #'\donttest{
-#' x <- try(load_geouy("Peajes"), silent = TRUE)
-#' if (!inherits(x, "try-error")) x1 <- which_uy(x, c = "Deptos")
+#' # Needs two external services: MTOP for the tolls and IDE for the departments.
+#' peajes_x_dpto <- try({
+#'   peajes <- load_geouy("Peajes")
+#'   which_uy(peajes, c = "Deptos")
+#' }, silent = TRUE)
+#' if (!inherits(peajes_x_dpto, "try-error")) head(peajes_x_dpto)
 #'}
 
 which_uy <- function(x, c = c("Localidades pg", "Departamentos"), d = c("cod", "name")){

--- a/man/which_uy.Rd
+++ b/man/which_uy.Rd
@@ -21,8 +21,12 @@ This function allows to add to an 'sf' object its spatial coincidence with one o
 }
 \examples{
 \donttest{
-x <- try(load_geouy("Peajes"), silent = TRUE)
-if (!inherits(x, "try-error")) x1 <- which_uy(x, c = "Deptos")
+# Needs two external services: MTOP for the tolls and IDE for the departments.
+peajes_x_dpto <- try({
+  peajes <- load_geouy("Peajes")
+  which_uy(peajes, c = "Deptos")
+}, silent = TRUE)
+if (!inherits(peajes_x_dpto, "try-error")) head(peajes_x_dpto)
 }
 }
 \seealso{


### PR DESCRIPTION

Lo que faltaba del #3, más un bug que apareció al verificarlo.

### 1. Decir qué capa y qué servidor fallaron

El PR anterior dejó bien la rama de las capas en zip, pero las que se leen por WFS —que son la mayoría— seguían devolviendo el error crudo de GDAL:

```
Cannot open data source `https://...'; Check connection parameters.
```

Eso no dice qué capa se pidió ni a qué servidor, que es justo lo que hace falta para saber si el problema es de uno o es ajeno. Ahora las tres vías de lectura remota pasan por la misma función y el mensaje es uno solo:

```
Could not read the layer 'Secciones' from https://mapas.mides.gub.uy:443.
The server may be down or the layer may have changed.
Details: Cannot open "https://..."; Check connection parameters.
```

El error original queda al final a propósito: no todo fallo es del servidor, puede ser un cambio en la capa o un problema al leer lo que llegó.

Se atrapan errores y no warnings, también a propósito. Los handlers de `tryCatch` son de salida: alcanzaría con que GDAL emitiera un warning recuperable para que la lectura se abandonara y se perdiera un objeto que estaba bien.

Un dato que salió probando esto: **`geoservicios.sgm.gub.uy` ya no resuelve por DNS**. No hizo falta simular nada para ver el mensaje nuevo en esa rama. Son las tres capas del SGM (`Areas administrativas`, `Centros poblados pg` y `Centros poblados pt`). Lo dejo anotado acá porque entra en la conversación de capas caídas, no en este PR.

### 2. El que me preocupa: devolvía los datos de otra capa

Después de descargar, el código extraía el zip y se quedaba con el shapefile más reciente **de toda la carpeta**:

```r
invisible(try(utils::unzip(f, exdir = folder)))
archivo <- fs::dir_ls(folder, regexp = "\\.shp$")
archivo <- archivo[which.max(file.info(archivo)$mtime)]
```

`unzip()` no da error cuando el archivo no es un zip: avisa con un warning y devuelve `NULL`, y ese warning quedaba tapado por el `try()`. Entonces, si el servidor contestaba con una página de error servida como 200, o el zip venía cortado, la búsqueda encontraba el shapefile de **otra** capa bajada antes en la misma carpeta —que por omisión es `tempdir()` y se comparte entre llamadas— y `load_geouy()` devolvía esos datos como si fueran los pedidos, sin avisar.

Se reproduce sin tocar la red, porque la descarga se saltea si el archivo ya existe:

```r
carpeta <- tempfile(); dir.create(carpeta)
load_geouy("Deptos", folder = carpeta)             # 20 filas, bien
writeLines("no soy un zip", file.path(carpeta, "Localidades pt.zip"))
load_geouy("Localidades pt", folder = carpeta)     # 20 filas: ¡son Deptos!
```

Devolver datos equivocados en silencio es peor que fallar, sobre todo acá, donde el resultado se cruza con otras capas y el error termina apareciendo lejos del lugar donde se produjo.

Ahora se usa lo que `unzip()` dice haber extraído y se busca el `.shp` ahí adentro. Si no hay ninguno, se corta diciendo que el servidor contestó pero no con lo esperado. De paso se borra el archivo que no servía: si quedaba, la comprobación de más arriba salteaba la descarga y todas las llamadas siguientes fallaban igual, sin manera de recuperarse salvo cambiar de carpeta. Con el ejemplo de arriba, la segunda llamada ahora corta con el mensaje y al reintentarla baja las 652 localidades que corresponden.

### 3. El ejemplo de `which_uy()`

Quedaba a medias. Envolvía en `try()` la carga de «Peajes», pero `which_uy()` vuelve a salir a la red por dentro para traer la capa contra la que hace el cruce, y esa segunda descarga estaba sin cubrir:

```r
x <- try(load_geouy("Peajes"), silent = TRUE)
if (!inherits(x, "try-error")) x1 <- which_uy(x, c = "Deptos")
```

Y no son el mismo servidor: «Peajes» sale de `geoservicios.mtop.gub.uy` y «Deptos» de `mapas.ide.uy`. Alcanza con que responda uno y no el otro para que el ejemplo reviente y el check termine en ERROR.

Ahora el `try()` abarca las dos llamadas. Lo comprobé dejando accesible sólo MTOP y bloqueando `mapas.ide.uy`, que es el caso que discrimina: con el ejemplo anterior el error sube al check, con este no.

### 4. Que el error diga la causa que el servidor reportó

Esto lo agregué después, y salió de algo que me pasó investigando las capas de
Ambiente: las di por caídas cuando el servidor estaba vivo. El detalle está en
el #30, pero el pedazo que le toca a esta rama es que **el mensaje me escondió
la causa**.

GDAL sí sabe qué pasa. Lo dice:

```
GDAL Error 1: SSL certificate problem: unable to get local issuer certificate
```

Pero lo dice en un **warning**, y después tira un error genérico que no lo
menciona:

```
Error: Cannot open "https://..."; Check connection parameters.
```

Como `descarga_o_falla()` sólo miraba el error, al usuario le llegaba
"el servidor puede estar caído" cuando el servidor estaba perfecto y lo que le
faltaba era la cadena de certificados. Son dos problemas muy distintos de
resolver, y el mensaje los volvía indistinguibles.

Ahora los avisos se copian con `withCallingHandlers()` y se suman al detalle.
La diferencia se ve mejor con los dos casos al lado:

```
Could not read the layer 'Areas protegidas' from https://www.ambiente.gub.uy.
Details: Cannot open "..."; Check connection parameters.
GDAL Error 1: SSL certificate problem: unable to get local issuer certificate

Could not read the layer 'Centros poblados pg' from https://geoservicios.sgm.gub.uy.
Details: Cannot open "..."; The file doesn't seem to exist.
GDAL Error 1: Could not resolve host: geoservicios.sgm.gub.uy
```

Uno dice certificado y el otro dice DNS. Antes los dos decían lo mismo.

Tres detalles de cómo está hecho:

- **No se muffle-an los avisos.** Se copian y siguen su camino, así que una
  lectura que igual funciona no pierde los avisos que el usuario tendría que
  ver. Por eso va `withCallingHandlers()` y no un `tryCatch(warning = ...)`,
  que al ser de salida abortaría la lectura.
- **Hay un tope de cinco y se descarta lo repetido.** Con
  `options(warn = 2)` el aviso ya viene adentro del error, y sin tope un fallo
  detrás de muchos avisos deja un mensaje ilegible; además `stop()` corta a
  8190 caracteres, lo comprobé. En los tres fallos reales que medí
  —certificado, capa inexistente y host que no resuelve— GDAL emite uno solo,
  así que el tope casi nunca entra en juego.
- **Cuando hay causa, el mensaje deja de especular.** Decir "el servidor puede
  estar caído" arriba de un detalle que dice "SSL certificate problem" es
  contradecirse. Cuando no hay ningún aviso la frase sigue apareciendo, porque
  ahí sí es lo único que se puede ofrecer. La decisión es por si hay aviso o
  no, y no por lo que el aviso diga: los textos cambian entre versiones de GDAL
  y entre idiomas, y colgar el comportamiento de ahí se rompe solo.

Lo verifiqué con control positivo y por rotura: con el cambio el mensaje nombra
el certificado, y con la versión anterior no lo nombra. Si esa segunda parte no
diera negativo, la prueba no estaría probando nada.

### Cómo quedó el check

`R CMD check --as-cran` sin errores ni warnings. Los NOTEs que quedan son los mismos de siempre y ninguno es del paquete.

Con esto queda cerrado el #3.

