### PR TITLE
El vuelo urbano deja de ser sólo Montevideo: 86 localidades

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,21 @@
 * `tiles_geouy()` now fails with an informative message when the geometry has
   no area to crop.
 
+* `tiles_geouy(urban = TRUE)` now works for the whole country. The urban flight
+  covers 86 localities across ten deliveries, but only Montevideo was reachable:
+  the download URLs were built by hand and the per-city folder in the path
+  ("01_Ciudad_MVD") is sequential within each delivery, so it could not be
+  derived from the locality code. The layer already ships the complete URLs, so
+  they are taken from it and the locality filter is gone.
+* `tiles_geouy()` no longer leaves a half-downloaded file under its final name.
+  Each file is downloaded to a temporary name in the same folder and renamed
+  only once it is complete, so an interrupted download can no longer be read
+  back as if it were valid.
+* `tiles_geouy()` now reports which file failed to download. The `.jpg` and its
+  world file used to be requested in a single call, and `download.file()`
+  returns 0 when at least one of several URLs succeeds, so a missing world file
+  went unnoticed and the raster was left ungeoreferenced.
+
 ## geouy v0.2.8 (2023-08-22)
 
 * update geouy.R for changes in roxygen2

--- a/R/tiles_geouy.R
+++ b/R/tiles_geouy.R
@@ -4,7 +4,7 @@
 #' @param d numeric; buffer distance for all, or for each of the elements in x; in case dist is a units object, it should be convertible to arc_degree if x has geographic coordinates, and to st_crs(x)$units otherwise. Default NA, but if x is a only one point buffer default is 100.
 #' @param format Format of the archives to download (avaiable: "rgb" and "rgbi") Default "rgb"
 #' @param folder Folder where are the files or be download
-#' @param urban logical; If FALSE take orthophotos of national flight with 32cm per pixel, if TRUE take urban flight with 10cm per pixel (avaible only Montevideo at the moment)
+#' @param urban logical; If FALSE take orthophotos of national flight with 32cm per pixel, if TRUE take urban flight with 10cm per pixel (available for every locality covered by the urban flight)
 #' @keywords IDE orthophotos Uruguay
 #' @return raster::stack object with th cropped tif corresponding to x bbox
 #' @importFrom sf st_join st_crs st_bbox st_transform
@@ -34,9 +34,7 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
   if (!format %in% c("rgb", "rgbi")) stop("The format you want to download is not avaiable")
   if (!curl::has_internet()) stop("No internet access detected. Please check your connection.")
    # download ----
-  start_time <- Sys.time()
   suppressWarnings(try(dir.create(folder)))
-  crs = sf::st_crs(x)
   if (nrow(x) == 1 & is.na(d)) x <- sf::st_buffer(x, dist = 100)
   if (!is.na(d)) x <- sf::st_buffer(x, dist = d)
   # El area de recorte se arma pasando el bbox a geometria: asi no depende del
@@ -64,7 +62,10 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
     x2 <- x2 %>% 
       sf::st_join(x %>% sf::st_transform(5381), left = F) %>% 
       dplyr::distinct(.data$nombre, .keep_all = TRUE)
-    if (nrow(x2) == 0) stop(glue::glue("The geometry you have in {x} is not in Uruguay. Verify in the metadata file"))
+    if (nrow(x2) == 0) {
+      stop("The geometry in x is not in Uruguay, or its crs is not the one it ",
+           "declares.", call. = FALSE)
+    }
   } else {
     # Idem grilla nacional: se comprueba el resultado de la descarga, no sus NA.
     x2 <- try(geouy::load_geouy("Grilla ortofotos urbana", crs = 5381), silent = TRUE)
@@ -72,55 +73,55 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
       stop("IDEuy Server out of service, try in https://visualizador.ide.uy/ideuy/core/load_public_project/ideuy/\n",
            "Details: ", conditionMessage(attr(x2, "condition")), call. = FALSE)
     }
+    # Ya no se filtra por localidad: el vuelo urbano cubre 86 y el st_join con la
+    # geometria del usuario alcanza para quedarse con los tiles que le sirven.
     x2 <- x2 %>%
-      # La grilla urbana identifica las localidades por codigo ("MVD"), no por
-      # nombre completo, desde que el vuelo urbano se extendio a otras ciudades.
-      dplyr::filter(.data$localidad == "MVD") %>%
-      sf::st_join(x %>% sf::st_transform(5381), left = F) %>% 
-      dplyr::mutate(nombre = as.character(.data$nombre)) %>% 
+      sf::st_join(x %>% sf::st_transform(5381), left = F) %>%
       dplyr::distinct(.data$nombre, .keep_all = TRUE)
-    if (nrow(x2) == 0) stop(glue::glue("The geometry you have in {x} is not in Montevideo. Verify in the metadata file"))
+    if (nrow(x2) == 0) {
+      stop("No urban-flight orthophotos cover the geometry in x. ",
+           "Use urban = FALSE for the national flight, which covers the whole ",
+           "country at 32 cm per pixel, or check the crs of x.", call. = FALSE)
+    }
   }
   
-  # Para formato rgb ----
+  # Descarga ----
+  # Las URLs vienen en la propia capa, una columna por formato. Antes se armaban
+  # con glue(), lo que obligaba a escribir fija la carpeta de la ciudad
+  # ("01_Ciudad_MVD"): ese numero es correlativo dentro de cada remesa y no se
+  # puede deducir del codigo de localidad, y por eso el vuelo urbano estaba
+  # limitado a Montevideo. Tomandolas de la capa quedan disponibles las 86
+  # localidades, y ademas deja de importar como reordene la IDE sus carpetas.
   if (format == "rgb") {
-    if (urban == FALSE) {
-      a <- glue::glue("https://visualizador.ide.uy/descargas/datos/CN_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}/02_Ortoimagenes/03_RGB_8bits/{as.character(x2$nombre)}_RGB_8_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}")
-    } else {
-      a <- glue::glue("https://visualizador.ide.uy/descargas/datos/CU_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}/02_Ortoimagenes/01_Ciudad_MVD/03_RGB_8bits/{as.character(x2$nombre)}_RGB_8_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}_MVD")
+    # El .jgw es el world file. Sin el, el .jpg no queda georreferenciado y el
+    # recorte posterior trabajaria sobre coordenadas de pixel: hay que bajarlo,
+    # aunque el que se lee despues sea el .jpg.
+    rasters <- as.character(x2$rgb_jpg)
+    urls <- c(rasters, as.character(x2$rgb_jgw))
+  } else {
+    rasters <- as.character(x2$rgbi_8bits)
+    urls <- rasters
+  }
+  destinos <- file.path(folder, basename(urls))
+  for (i in seq_along(urls)) {
+    message(glue::glue("Trying to download {basename(urls[i])}..."))
+    # De a una URL por vez. download.file() con un vector devuelve 0 si al menos
+    # una de las descargas anduvo, asi que el par .jpg/.jgw se bajaba junto y un
+    # world file faltante pasaba inadvertido: el raster quedaba sin georreferenciar.
+    estado <- tryCatch(
+      utils::download.file(urls[i], destinos[i], mode = "wb", method = "libcurl"),
+      error = function(e) e)
+    if (inherits(estado, "error") || !identical(as.integer(estado), 0L)) {
+      stop(glue::glue("Could not download '{basename(urls[i])}' from the IDEuy tiles ",
+                      "repository. The server may be out of service, try in ",
+                      "https://visualizador.ide.uy/ideuy/core/load_public_project/ideuy/"),
+           call. = FALSE)
     }
-    for (i in 1:length(a)) {
-      if (!file.exists(a[i])) {
-        message(glue::glue("Trying to download..."))
-        try(utils::download.file(glue::glue("{a[i]}{c('.jpg','.jgw')}"), 
-                                 glue::glue("{folder}//{basename(a[i])}{c('.jpg','.jgw')}"), 
-                                 mode = "wb", method = "libcurl",
-                                 extra = '--no-check-certificate'))
-      } 
-    }
-    # read brick
-    ar <- fs::dir_ls(folder,  regexp = "\\.jpg$")
-    ar <- ar[file.info(ar)$mtime > start_time]
-  } 
-  # Para formato rgbi ----
-  if (format == "rgbi") {
-    if (urban == FALSE) {
-      a <- glue::glue("https://visualizador.ide.uy/descargas/datos/CN_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}/02_Ortoimagenes/02_RGBI_8bits/{as.character(x2$nombre)}_RGBI_8_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}.tif")
-    } else {
-      a <- glue::glue("https://visualizador.ide.uy/descargas/datos/CU_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}/02_Ortoimagenes/01_Ciudad_MVD/02_RGBI_8bits/{as.character(x2$nombre)}_RGBI_8_Remesa_{stringr::str_pad(x2$remesa, 2, pad = '0')}_MVD.tif")
-    }
-    for (i in 1:length(a)) {
-      if (!file.exists(a[i])) {
-        message(glue::glue("Trying to download..."))
-        try(utils::download.file(a[i], glue::glue("{folder}//{basename(a[i])}"), 
-                                 mode = "wb", method = "libcurl",
-                                 extra = '--no-check-certificate'))
-      } 
-    }
-    # read brick ----
-    ar <- fs::dir_ls(folder, regexp = "\\.tif$")
-    ar <- ar[file.info(ar)$mtime > start_time]
-  } 
+  }
+  # Se leen exactamente los archivos de esta consulta. Antes se barria la carpeta
+  # buscando cualquier .jpg y se filtraba por fecha de modificacion, lo que tomaba
+  # archivos ajenos y a la vez dejaba fuera los que ya estuvieran descargados.
+  ar <- file.path(folder, basename(rasters))
   # Return ----
   if (length(ar) == 1) {
     a3 <- raster::brick(ar)

--- a/R/tiles_geouy.R
+++ b/R/tiles_geouy.R
@@ -1,3 +1,34 @@
+# Bajar directamente al destino deja un archivo a medias si la descarga se corta,
+# y ese archivo despues se toma por bueno: probado con un .jpg recortado al 40%,
+# la funcion devuelve un raster sin avisar nada. Bajando a un temporal en la misma
+# carpeta y renombrando solo al terminar bien, una interrupcion deja un ".part"
+# que nadie mira, y el destino solo existe si esta completo.
+descarga_tile <- function(url, destino) {
+  temporal <- tempfile(paste0(basename(destino), ".part-"), tmpdir = dirname(destino))
+  on.exit(unlink(temporal), add = TRUE)
+  estado <- tryCatch(
+    utils::download.file(url, temporal, mode = "wb", method = "libcurl"),
+    error = function(e) e)
+  detalle <- if (inherits(estado, "error")) {
+    conditionMessage(estado)
+  } else if (!identical(as.integer(estado), 0L)) {
+    glue::glue("download.file() returned status {as.integer(estado)}")
+  } else if (!isTRUE(file.size(temporal) > 0)) {
+    "the downloaded file is empty"
+  }
+  if (!is.null(detalle)) {
+    stop(glue::glue("Could not download '{basename(url)}' from the IDEuy tiles ",
+                    "repository. The server may be out of service, try in ",
+                    "https://visualizador.ide.uy/ideuy/core/load_public_project/ideuy/\n",
+                    "Details: {detalle}"), call. = FALSE)
+  }
+  if (!file.rename(temporal, destino)) {
+    stop(glue::glue("Downloaded '{basename(url)}' but could not move it into {dirname(destino)}."),
+         call. = FALSE)
+  }
+  invisible(destino)
+}
+
 #' This function allows to Download .jpg or .tif files from the IDEuy tiles repository, according to a 'sf' object bbox.
 #' @family service
 #' @param x An 'sf' object with the same crs as the homonym parameter
@@ -103,20 +134,29 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
     urls <- rasters
   }
   destinos <- file.path(folder, basename(urls))
+  # Dos tiles distintos que compartieran nombre de archivo se pisarian en la
+  # carpeta, y el segundo ni siquiera se bajaria porque el primero ya existe.
+  # Hoy no pasa -37.400 nombres entre las dos grillas y los cuatro formatos, sin
+  # una sola repeticion-, pero si la IDE cambiara el esquema conviene que se note
+  # aca y no en un raster con un tile repetido y otro faltante.
+  if (anyNA(urls) || anyDuplicated(destinos)) {
+    stop("The IDEuy tile layer returned unusable download URLs (missing, or ",
+         "different tiles sharing one file name). Please report this.", call. = FALSE)
+  }
   for (i in seq_along(urls)) {
+    # Aca habia un `if (!file.exists(a[i]))` sobre la URL, que nunca es un
+    # archivo: siempre daba FALSE, asi que la funcion se rebajaba todo en cada
+    # llamada. Se saca por ser codigo muerto, pero no se lo reemplaza por la
+    # comprobacion sobre el archivo local, que seria lo obvio: un archivo a
+    # medias de un intento anterior tiene tamano mayor que cero y se daria por
+    # bueno. Probado con un .jpg recortado al 40%: la funcion devuelve un raster
+    # sin avisar. Un cache de verdad tiene que validar lo que ya esta en disco
+    # contra el servidor, y eso va con el issue de no rebajar 70 MB cada vez.
     message(glue::glue("Trying to download {basename(urls[i])}..."))
     # De a una URL por vez. download.file() con un vector devuelve 0 si al menos
     # una de las descargas anduvo, asi que el par .jpg/.jgw se bajaba junto y un
     # world file faltante pasaba inadvertido: el raster quedaba sin georreferenciar.
-    estado <- tryCatch(
-      utils::download.file(urls[i], destinos[i], mode = "wb", method = "libcurl"),
-      error = function(e) e)
-    if (inherits(estado, "error") || !identical(as.integer(estado), 0L)) {
-      stop(glue::glue("Could not download '{basename(urls[i])}' from the IDEuy tiles ",
-                      "repository. The server may be out of service, try in ",
-                      "https://visualizador.ide.uy/ideuy/core/load_public_project/ideuy/"),
-           call. = FALSE)
-    }
+    descarga_tile(urls[i], destinos[i])
   }
   # Se leen exactamente los archivos de esta consulta. Antes se barria la carpeta
   # buscando cualquier .jpg y se filtraba por fecha de modificacion, lo que tomaba

--- a/man/tiles_geouy.Rd
+++ b/man/tiles_geouy.Rd
@@ -15,7 +15,7 @@ tiles_geouy(x, d = NA, format = "rgb", folder = tempdir(), urban = FALSE)
 
 \item{folder}{Folder where are the files or be download}
 
-\item{urban}{logical; If FALSE take orthophotos of national flight with 32cm per pixel, if TRUE take urban flight with 10cm per pixel (avaible only Montevideo at the moment)}
+\item{urban}{logical; If FALSE take orthophotos of national flight with 32cm per pixel, if TRUE take urban flight with 10cm per pixel (available for every locality covered by the urban flight)}
 }
 \value{
 raster::stack object with th cropped tif corresponding to x bbox


### PR DESCRIPTION
Cierra lo del #4.

### El vuelo urbano deja de ser sólo Montevideo

La grilla urbana tiene **2753 tiles en 86 localidades**, pero `urban = TRUE` sólo alcanzaba los 477 de Montevideo.

El motivo estaba en cómo armábamos la URL: en la ruta va una carpeta por ciudad, y ese número es correlativo dentro de cada remesa, no derivable del código de localidad. Maldonado es `01_Ciudad_MDO` en la remesa 02 y Salto es `06_Ciudad_SAL` en la 04. Como no había forma de calcularlo, quedó escrito fijo `01_Ciudad_MVD`, y con él el filtro `localidad == "MVD"`.

No hace falta calcular nada: la capa ya trae las URLs completas. Antes de cambiar nada verifiqué dos cosas:

- Las columnas `rgb_jpg`, `rgb_jgw`, `rgbi_8bits` y `rgbi_16bit` vienen **sin un solo NA** en las dos grillas (2753 y 6597 filas).
- Y son **idénticas** a las que armaba `glue()`: 477 de 477 en Montevideo, 6597 de 6597 en la nacional para `.jpg`, y otras tantas para `.tif`.

O sea que no cambia nada de lo que hoy funciona. Lo comprobé también de punta a punta, con un punto en Montevideo:

| | antes | ahora |
|---|---|---|
| dimensiones | 1007x1007x3 | 1007x1007x3 |
| extent | 558963.6 559064.3 6150975.2 6151075.9 | igual |
| suma de píxeles | 775747485 | 775747485 |

Y con puntos en Salto y Maldonado, que antes daban error, ahora devuelve el recorte correcto.

### Dos cosas que aparecieron mientras lo verificaba

**Una descarga cortada dejaba un archivo que después se daba por bueno.** Recorté un `.jpg` al 40% y `raster` lo abre igual: la función devuelve un recorte sin avisar nada. Si la ventana pedida cae en la parte que sobrevivió el resultado hasta parece correcto, y si cae en la que falta, no. Con el archivo en cero bytes el error es «Cannot create a RasterLayer object from this file», que no dice dónde mirar. Ahora cada archivo se baja a un temporal en la misma carpeta y se renombra recién cuando terminó bien y no está vacío.

**El `.jpg` y su world file se pedían en una sola llamada.** `?download.file` dice que con varias URLs devuelve 0 si al menos una anduvo, así que un `.jgw` faltante pasaba inadvertido y el raster quedaba sin georreferenciar. Ahora va de a uno y se comprueba cada descarga.

### Sobre el caché, que decidí no agregar

El `if (!file.exists(a[i]))` comprobaba la URL, que nunca es un archivo: siempre daba FALSE, así que la función se rebajaba todo en cada llamada. Era código muerto y lo saqué.

Lo obvio sería reemplazarlo por la comprobación sobre el archivo local, y lo hice, pero lo deshice: eso reintroduce el problema de arriba para cualquier archivo que no haya creado esta versión, y un `size > 0` no alcanza porque truncado no es vacío. Un caché de verdad tiene que validar contra el servidor lo que ya está en disco, y me pareció que va junto con el #7, que es donde el tema es no rebajar 70 MB cada vez. Preferí no dejar acá una función con un modo de fallo que ya había visto y no cerrado.

### Detalles

- Los dos mensajes de «tu geometría no está acá» interpolaban el objeto `sf` entero: pedir un punto de Salto imprimía miles de coordenadas antes del mensaje. Ahora dicen qué pasó, qué hacer, y mencionan el `crs`, que es la causa más común de que no intersecte nada.
- Hay una guarda nueva sobre los nombres de archivo. Dos tiles distintos que compartieran `basename` se pisarían en la carpeta. Hoy no pasa —37.400 nombres entre las dos grillas y los cuatro formatos, sin una sola repetición— pero si la IDE cambiara el esquema conviene que se note ahí y no en un raster con un tile repetido y otro faltante.
- La lectura ya no barre la carpeta buscando cualquier `.jpg`: usa los archivos de la consulta. Probado copiando un tile de Salto a la carpeta de una consulta de Montevideo, que ahora se ignora.
- `start_time` quedó sin uso al sacar el filtro por fecha, así que se va.

### Check

`R CMD check --as-cran` sin errores ni warnings. Los dos NOTEs son los de siempre y ninguno es del paquete.

Una cosa que no toqué y conviene saber: la rama del mosaico, para cuando el área abarca varios tiles, sigue con los problemas del #5.
