### PR TITLE
plot_geouy(): el mensaje que archivó el paquete, la escala y el tema global

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,21 @@
 * Examples that rely on remote services now check the result of the download
   before using it, so an unreachable server no longer turns into an error in
   `R CMD check`.
+* `plot_geouy()` now says which variable is missing instead of printing the
+  whole object. The message interpolated the `sf` object, and since `glue()` is
+  vectorised it produced one message per column, each carrying all its values.
+  This is what reached CRAN's check in 2025, when the "Secciones" layer stopped
+  shipping the variable the example asked for.
+* `plot_geouy()` now picks the colour scale from the type of the variable.
+  `discrete` was computed with `is.numeric()` on a one-column data frame, which
+  is always FALSE, so categorical variables were drawn on a continuous scale.
+* `plot_geouy()` now honours `viri_opt`, which was documented but ignored: the
+  scale had `option = "D"` hardcoded. The default stays viridis, so existing
+  maps keep their colours.
+* `plot_geouy()` no longer calls `theme_set()`, which changed the default
+  ggplot2 theme for the whole R session. The returned plot is unchanged.
+* `plot_geouy()` reports missing or invalid `other_lab` and `l` combinations up
+  front, instead of failing later while drawing.
 * Fix `tiles_geouy()`, which aborted on every call with a false "IDEuy Server
   out of service". The grid layers now carry administrative columns with
   legitimate NA values, so validating the download with `noNA()` always failed;

--- a/R/plot_geouy.R
+++ b/R/plot_geouy.R
@@ -12,13 +12,27 @@ listar <- function(v, max = 20) {
   else paste(v, collapse = ", ")
 }
 
+# ggplot2 clasifica factor, character y logical como discretos, y numericos y
+# fechas como continuos. La formula corta -"discreta si no es numerica"- deja
+# las fechas del lado equivocado: se dibujaban bien con la escala continua y
+# pasarian a tratarse como categorias. Lo demas (columnas de lista, geometrias)
+# no tiene escala razonable y conviene decirlo aca y no dejar que falle adentro
+# de ggplot con un mensaje que no menciona ni la variable ni la funcion.
+escala_discreta <- function(v, col) {
+  if (is.factor(v) || is.character(v) || is.logical(v)) return(TRUE)
+  if (is.numeric(v) || inherits(v, c("Date", "POSIXt"))) return(FALSE)
+  stop(glue::glue("The variable '{col}' is of type {class(v)[1]}, which cannot be ",
+                  "used as a fill scale. Use a numeric, date, character, factor ",
+                  "or logical variable."), call. = FALSE)
+}
+
 #' @name plot_geouy
 #' @title plot_geouy
 #' @description This function allows you to set ggplot2 theme in our suggested format.
 #' @family plot
 #' @param x An sf object like load_geouy() results
 #' @param col Variable of "x" to plot (character)
-#' @param viri_opt A character string indicating the colormap option to use. Four options are available: "magma" (or "A"), "inferno" (or "B"), "plasma" (or "C"), "viridis" (or "D", the default option) and "cividis" (or "E")
+#' @param viri_opt A character string indicating the colormap option to use. Five options are available: "magma" (or "A"), "inferno" (or "B"), "plasma" (or "C"), "viridis" (or "D", the default) and "cividis" (or "E")
 #' @param l If NULL none label added, if "\%" porcentage with 1 decimal labels, if "n" the value is the label, if "c" put other variable in other_lab. Default NULL
 #' @param other_lab If l is "c" put here the variable name for the labels.
 #' @param ... All parameters allowed from ggplot2 themes.
@@ -35,7 +49,7 @@ listar <- function(v, max = 20) {
 #' }
 #' 
 
-plot_geouy <- function(x, col, viri_opt = "plasma", l = NULL, other_lab = NULL, ...){
+plot_geouy <- function(x, col, viri_opt = "D", l = NULL, other_lab = NULL, ...){
   try(if (!methods::is(x, "sf")) stop("The object you want to process is not class sf"))
   # El mensaje interpolaba {x}, el objeto sf completo. Y glue() vectoriza, asi
   # que no armaba un mensaje largo: armaba uno por cada columna, con todos sus
@@ -67,8 +81,12 @@ plot_geouy <- function(x, col, viri_opt = "plasma", l = NULL, other_lab = NULL, 
   theme_set(theme_bw())
   mapa <- ggplot2::ggplot(data = x) +
     ggplot2::geom_sf(data = x, aes(!!!ensyms(fill = col)))  +
-    viridis::scale_fill_viridis(name = col, option = "D", direction = -1,
-                                discrete = is.numeric(x[,col] %>% sf::st_set_geometry(NULL))) +
+    # x[[col]] devuelve el vector; x[,col] devuelve un sf de una columna, y
+    # is.numeric() de un data.frame es siempre FALSE, con o sin geometria, asi
+    # que discrete quedaba en FALSE para todo. Con numericas acertaba de
+    # casualidad; con categoricas no.
+    viridis::scale_fill_viridis(name = col, option = viri_opt, direction = -1,
+                                discrete = escala_discreta(x[[col]], col)) +
     ggplot2::xlab(NULL) + ggplot2::ylab(NULL) +
     labs(title = glue::glue("Mapa de variable: {tolower(col)}")) +
     theme_light() +

--- a/R/plot_geouy.R
+++ b/R/plot_geouy.R
@@ -1,3 +1,17 @@
+# Las variables que el usuario puede pedir son las columnas menos la geometria:
+# ofrecerle "geometry" como opcion valida solo confunde. Se usa la misma lista
+# para validar y para el mensaje, para que no puedan decir cosas distintas.
+variables_de <- function(x) {
+  setdiff(names(x), attr(x, "sf_column", exact = TRUE))
+}
+
+# El mensaje no vuelca datos, pero una tabla muy ancha igual da una lista larga.
+listar <- function(v, max = 20) {
+  if (length(v) > max) paste0(paste(v[seq_len(max)], collapse = ", "),
+                              ", ... (", length(v) - max, " more)")
+  else paste(v, collapse = ", ")
+}
+
 #' @name plot_geouy
 #' @title plot_geouy
 #' @description This function allows you to set ggplot2 theme in our suggested format.
@@ -23,9 +37,29 @@
 
 plot_geouy <- function(x, col, viri_opt = "plasma", l = NULL, other_lab = NULL, ...){
   try(if (!methods::is(x, "sf")) stop("The object you want to process is not class sf"))
-  assertthat::assert_that(col %in% names(x), msg = glue::glue("Sorry... :( \n The name of the variable you will plot is not in the object {x}"))
+  # El mensaje interpolaba {x}, el objeto sf completo. Y glue() vectoriza, asi
+  # que no armaba un mensaje largo: armaba uno por cada columna, con todos sus
+  # valores adentro. Cuando una capa cambia y deja de traer la variable pedida
+  # -que es lo que paso con "Secciones" y el Censo 2023- lo que sale es una
+  # avalancha en lugar del nombre que falta.
+  disponibles <- variables_de(x)
+  assertthat::assert_that(col %in% disponibles,
+    msg = glue::glue("The variable '{col}' is not in x. Available: {listar(disponibles)}"))
   if (!is.null(l)) assertthat::assert_that(l %in% c("%", "n", "c"), msg = "Sorry... :( \n l parameter is not a valid value, please review!.")
-  if (!is.null(other_lab) && l %in% "c") assertthat::assert_that(other_lab %in% names(x), msg = glue::glue("Sorry... :( \n The name of the variable you will plot is not in the object {x}"))
+  # isTRUE() alrededor del %in%: con l = NULL el %in% da logical(0), y
+  # `TRUE && logical(0)` da NA, con lo cual el if se cae con "valor ausente
+  # donde TRUE/FALSE es necesario" con solo pedir other_lab sin pedir l. Con l
+  # de largo 2 el && directamente da error desde R 4.3. isTRUE() resuelve los
+  # dos casos y conserva la coercion del %in%, que acepta un factor.
+  if (isTRUE(l %in% "c")) {
+    # Pedir etiquetas de otra variable sin decir cual fallaba mas adelante, al
+    # dibujar, con "Problem while computing aesthetics".
+    assertthat::assert_that(!is.null(other_lab),
+      msg = "other_lab must be given when l is \"c\": it names the variable to label with.")
+    assertthat::assert_that(other_lab %in% disponibles,
+      msg = glue::glue("The variable '{other_lab}' given in other_lab is not in x. ",
+                       "Available: {listar(disponibles)}"))
+  }
   if (!is.null(l) && l %in% "%" & is.numeric(x[[col]]) & sum(x[[col]] > 1, na.rm = T) == 0) {
       x[[col]] <- x[[col]] * 100
     }

--- a/R/plot_geouy.R
+++ b/R/plot_geouy.R
@@ -77,8 +77,7 @@ plot_geouy <- function(x, col, viri_opt = "D", l = NULL, other_lab = NULL, ...){
   if (!is.null(l) && l %in% "%" & is.numeric(x[[col]]) & sum(x[[col]] > 1, na.rm = T) == 0) {
       x[[col]] <- x[[col]] * 100
     }
-  
-  theme_set(theme_bw())
+
   mapa <- ggplot2::ggplot(data = x) +
     ggplot2::geom_sf(data = x, aes(!!!ensyms(fill = col)))  +
     # x[[col]] devuelve el vector; x[,col] devuelve un sf de una columna, y

--- a/man/plot_geouy.Rd
+++ b/man/plot_geouy.Rd
@@ -4,14 +4,14 @@
 \alias{plot_geouy}
 \title{plot_geouy}
 \usage{
-plot_geouy(x, col, viri_opt = "plasma", l = NULL, other_lab = NULL, ...)
+plot_geouy(x, col, viri_opt = "D", l = NULL, other_lab = NULL, ...)
 }
 \arguments{
 \item{x}{An sf object like load_geouy() results}
 
 \item{col}{Variable of "x" to plot (character)}
 
-\item{viri_opt}{A character string indicating the colormap option to use. Four options are available: "magma" (or "A"), "inferno" (or "B"), "plasma" (or "C"), "viridis" (or "D", the default option) and "cividis" (or "E")}
+\item{viri_opt}{A character string indicating the colormap option to use. Five options are available: "magma" (or "A"), "inferno" (or "B"), "plasma" (or "C"), "viridis" (or "D", the default) and "cividis" (or "E")}
 
 \item{l}{If NULL none label added, if "\%" porcentage with 1 decimal labels, if "n" the value is the label, if "c" put other variable in other_lab. Default NULL}
 


### PR DESCRIPTION
Cierra el #13, el #14 y el #16, más dos cosas que aparecieron leyendo la función.

Todo se verifica sin red: son bugs de lógica y de mensajes, así que las pruebas van sobre un `sf` sintético de tres filas.

### Una cosa para decidir vos, primero

`viri_opt` tenía una contradicción de tres puntas: la **firma** decía `viri_opt = "plasma"`, la **documentación** decía que `"D"` es el default, y el **código** tenía `option = "D"` escrito fijo, ignorando el parámetro.

Alineé la firma a `"D"`, que es lo que produjeron todos los mapas del paquete hasta hoy, así ninguno cambia de color al arreglar el parámetro. Si preferís que el default sea plasma es cambiar una palabra, pero me pareció que esa decisión es tuya y no algo para meter de costado en un arreglo.

### El mensaje de error que archivó el paquete (#13)

Cuando la variable pedida no está, el mensaje interpolaba `{x}`, el objeto `sf` completo. Y `glue()` vectoriza, así que no armaba un mensaje: armaba **uno por cada columna**, con todos sus valores. Medido con un `sf` de tres columnas: cuatro mensajes, 465 caracteres.

Es el mecanismo exacto del archivo de 2025: «Secciones» cambió al Censo 2023, dejó de traer la variable del ejemplo, saltó la aserción y eso fue lo que llegó al chequeo de CRAN. El bug no fue que faltara la columna —eso es normal y hay que preverlo— sino el mensaje.

Ahora dice lo único útil, y corta la lista a las primeras veinte por si la tabla es ancha:

```
The variable 'noexiste' is not in x. Available: nom, pob, tipo
```

De paso, la lista de disponibles ahora es la misma que usa la validación. Antes se validaba contra `names(x)`, así que pedir `col = "geometry"` pasaba el control y fallaba después adentro de ggplot.

### La escala de color (#14)

```r
discrete = is.numeric(x[,col] %>% sf::st_set_geometry(NULL))
```

`x[,col]` sobre un `sf` no devuelve un vector: devuelve un `sf` de una columna, y `is.numeric()` de un data.frame es **siempre FALSE**. O sea que la escala era continua para todo: con numéricas acertaba de casualidad, y con categóricas viridis las trataba como continuas. La condición además estaba invertida.

Casi meto una regresión acá. Mi primera versión fue `!is.numeric(x[[col]])`, y las fechas no son numéricas: con eso pasaban a tratarse como categorías cuando hoy se dibujan bien. Lo probé y da «Continuous value supplied to a discrete scale». Así que la clasificación sigue la de ggplot2 —factor, texto y lógico discretos; numéricos y fechas continuos— y lo que no entra en ninguna, como una columna de listas, se avisa al entrar nombrando la variable y su tipo, en vez de fallar adentro de ggplot.

### El tema global (#16)

`theme_set(theme_bw())` en medio de la función cambia el tema por omisión de **toda la sesión de R**. Después de llamar a `plot_geouy()` una vez, cualquier ggplot que el usuario haga después sale distinto.

```r
ggplot2::theme_get()$panel.background$fill
#> "#EBEBEBFF"
plot_geouy(x, "pob")
ggplot2::theme_get()$panel.background$fill
#> "white"          # y queda asi
```

Y no hacía falta: la cadena aplica `theme_light()` tres líneas más abajo, que es un tema completo y reemplaza todo. Lo comprobé dibujando el mismo mapa antes y después, con el tema global en su valor de fábrica: **los PNG salen idénticos byte a byte**, tanto el mapa simple como el que lleva etiquetas.

### Dos bugs más, que aparecieron leyendo

**`viri_opt` no se usaba.** Comprobado pidiendo "plasma", "magma" y "viridis": las tres devolvían el mismo primer color, `#440154`, que es viridis.

No agregué validación del valor. Viridis acepta más paletas que las cinco documentadas —`rocket`, `mako` y `turbo` también andan— y ante un valor inválido avisa y usa viridis en lugar de fallar. Una lista fija acá rompería paletas que hoy funcionan y quedaría vieja sola.

**Las combinaciones de `l` y `other_lab` fallaban feo.** Pedir `other_lab` sin `l` rompía la función: `NULL %in% "c"` da `logical(0)`, y `TRUE && logical(0)` da `NA`, así que el `if` se caía con «valor ausente donde TRUE/FALSE es necesario». Y pedir `l = "c"` sin `other_lab` fallaba recién al dibujar, con «Problem while computing aesthetics». Las dos avisan ahora al entrar.

### Check

`R CMD check --as-cran` sin errores ni warnings; los dos NOTEs son los de siempre.

Las tres ramas abiertas se fusionan solas en cualquier orden: lo probé combinándolas de a pares y las tres juntas.
