### PR TITLE
Un chequeo semanal que avisa cuando una capa deja de responder

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,6 @@
 ^geouy\.Rcheck$
 ^geouy.*\.tar\.gz$
 ^geouy.*\.tgz$
+^chequeo-capas\.md$
+^chequeo-capas\.rds$
+^chequeo-capas\.estado$

--- a/.github/scripts/chequeo-capas.R
+++ b/.github/scripts/chequeo-capas.R
@@ -1,0 +1,135 @@
+# Recorre las capas del metadata y comprueba que cada servicio siga respondiendo.
+#
+# A proposito NO usa el paquete ni sf: lee data/metadata.rda directo y consulta
+# con curl. Asi el chequeo corre sin compilar el stack espacial y no se cae por un
+# problema de instalacion, que no es lo que quiere detectar. La contracara es que
+# esto es una prueba de humo del servicio: dice si el servicio esta y la capa
+# existe, no que sf pueda leerla y transformarla.
+#
+# Tampoco baja las capas enteras: pide una sola feature. Bajarlas completas serian
+# gigabytes por semana contra servidores del Estado, y CONEAT sola tarda cuatro
+# minutos.
+
+if (!nzchar(Sys.which("curl"))) stop("No se encontro curl en el PATH")
+load("data/metadata.rda")
+
+# Los formatos "zip" son de dos clases distintas y no se comprueban igual: 39 son
+# consultas WFS con outputFormat=shape-zip -o sea, se pueden acotar a una feature-
+# y 17 son archivos estaticos que pesan cientos de MB, a los que solo se les pide
+# la cabecera.
+es_wfs <- function(url) grepl("request=GetFeature", url, ignore.case = TRUE)
+es_archivo <- function(url, formato) formato %in% c("zip", "zip a") && !es_wfs(url)
+
+acotar <- function(url) {
+  # Si la capa ya declara un maxFeatures -Rutas trae 50- hay que reemplazarlo, no
+  # agregar un segundo parametro con el mismo nombre.
+  if (grepl("([?&])maxFeatures=", url, ignore.case = TRUE)) {
+    sub("maxFeatures=[^&#]*", "maxFeatures=1", url, ignore.case = TRUE)
+  } else {
+    paste0(url, if (grepl("?", url, fixed = TRUE)) "&" else "?", "maxFeatures=1")
+  }
+}
+
+endpoint <- function(url, repositor) {
+  # Las capas del SGM no traen URL: el campo guarda el nombre de la capa y la URL
+  # la arma load_geouy(). Se pide la capa concreta y no el GetCapabilities, porque
+  # si no las tres darian OK con que el servidor este vivo.
+  if (identical(repositor, "SGM")) {
+    return(paste0("http://geoservicios.sgm.gub.uy/wfsPCN1000.cgi",
+                  "?service=WFS&version=1.0.0&request=GetFeature",
+                  "&typeName=", utils::URLencode(url, reserved = TRUE),
+                  "&maxFeatures=1"))
+  }
+  url <- sub("^WFS:", "", url)
+  if (!grepl("^https?://", url, ignore.case = TRUE)) {
+    return(NA_character_)
+  }
+  if (es_wfs(url)) return(acotar(url))
+  # Endpoints WFS sin GetFeature (ArcGIS): solo se puede certificar el servicio.
+  if (grepl("WFSServer|/wfs", url, ignore.case = TRUE)) {
+    return(paste0(url, if (grepl("?", url, fixed = TRUE)) "&" else "?",
+                  "service=WFS&request=GetCapabilities"))
+  }
+  url
+}
+
+consultar <- function(url, solo_cabecera) {
+  cuerpo <- tempfile()
+  on.exit(unlink(cuerpo), add = TRUE)
+  args <- c("-sS", "-o", shQuote(cuerpo),
+            "-w", shQuote("GEOUY:%{http_code}:%{size_download}:%{url_effective}"),
+            "--connect-timeout", "15", "--max-time", "90", "-L",
+            "--retry", "2", "--retry-delay", "5", "--retry-all-errors")
+  if (solo_cabecera) args <- c(args, "-I")
+  salida <- suppressWarnings(system2("curl", c(args, "--", shQuote(url)),
+                                     stdout = TRUE, stderr = FALSE))
+  estado <- attr(salida, "status"); if (is.null(estado)) estado <- 0L
+  linea <- grep("^GEOUY:", salida, value = TRUE)
+  if (estado != 0L || !length(linea)) {
+    return(list(codigo = "000", bytes = 0, url = url, curl = estado, texto = ""))
+  }
+  p <- strsplit(sub("^GEOUY:", "", linea[length(linea)]), ":", fixed = TRUE)[[1]]
+  n <- suppressWarnings(min(file.info(cuerpo)$size, 65536L))
+  texto <- if (!is.na(n) && n > 0) readChar(cuerpo, n, useBytes = TRUE) else ""
+  list(codigo = p[1], bytes = as.numeric(p[2]),
+       url = paste(p[-(1:2)], collapse = ":"), curl = 0L, texto = texto)
+}
+
+# Un 200 no alcanza: los geoserver contestan las excepciones con codigo 200 y un
+# XML de error. Uno de esos que vi media 507 bytes, asi que un umbral de tamano no
+# sirve; hay que mirar si lo que vino se parece a datos.
+clasificar <- function(r, solo_cabecera) {
+  if (r$curl != 0L || r$codigo == "000") return("sin respuesta")
+  if (!identical(r$codigo, "200")) return(paste("HTTP", r$codigo))
+  if (solo_cabecera) return(if (r$codigo == "200") "ok" else paste("HTTP", r$codigo))
+  if (grepl("ExceptionReport|ServiceException|<html", r$texto, ignore.case = TRUE))
+    return("el servicio devolvio un error")
+  if (grepl("^PK", r$texto)) return("ok")                       # un zip de verdad
+  if (grepl("<([[:alnum:]_.-]+:)?FeatureCollection\\b", r$texto, perl = TRUE) ||
+      grepl('"type"\\s*:\\s*"FeatureCollection"', r$texto, perl = TRUE)) return("ok")
+  if (grepl("<([[:alnum:]_.-]+:)?WFS_Capabilities\\b", r$texto, perl = TRUE)) return("ok")
+  "respondio algo que no son datos"
+}
+
+filas <- vector("list", nrow(metadata))
+for (i in seq_len(nrow(metadata))) {
+  capa <- metadata$capa[i]
+  url  <- endpoint(metadata$url[i], metadata$repositor[i])
+  if (is.na(url)) {
+    filas[[i]] <- data.frame(capa = capa, servidor = "-", motivo = "URL invalida en el metadata", ok = FALSE)
+    cat(sprintf("%-5s %-32s %s\n", "FALLA", capa, "URL invalida")); next
+  }
+  cab <- es_archivo(metadata$url[i], metadata$formato[i])
+  r <- consultar(url, cab)
+  motivo <- clasificar(r, cab)
+  filas[[i]] <- data.frame(capa = capa, servidor = sub("^(https?://[^/?]+).*", "\\1", r$url),
+                           motivo = motivo, ok = motivo == "ok")
+  cat(sprintf("%-5s %-32s %s\n", if (motivo == "ok") "ok" else "FALLA", capa, motivo))
+}
+res <- do.call(rbind, filas)
+caidas <- res[!res$ok, ]
+cat("\n==== ", nrow(res) - nrow(caidas), " de ", nrow(res), " capas responden ====\n", sep = "")
+
+saveRDS(res, "chequeo-capas.rds")
+# Una huella de QUE esta caido, sin fecha: el workflow la usa para no repetir el
+# mismo aviso cada semana cuando no cambio nada.
+writeLines(sort(sprintf("%s\t%s", caidas$capa, caidas$motivo)), "chequeo-capas.estado")
+
+con <- file("chequeo-capas.md", "w", encoding = "UTF-8")
+if (nrow(caidas) == 0) {
+  writeLines(sprintf("Las %d capas del metadata responden.", nrow(res)), con)
+} else {
+  limpiar <- function(x) gsub("[|`\r\n]", " ", x)
+  writeLines(c(
+    sprintf("**%d de %d capas no responden.**", nrow(caidas), nrow(res)), "",
+    "| Capa | Servidor | Qué pasa |", "|---|---|---|",
+    sprintf("| `%s` | %s | %s |", limpiar(caidas$capa), limpiar(caidas$servidor), limpiar(caidas$motivo)), "",
+    "Se pide una sola feature por capa, o la cabecera si es un archivo: esto dice",
+    "si el servicio está y la capa existe, no que los datos sigan siendo los mismos."), con)
+}
+close(con)
+
+# 2 es el hallazgo esperado, o sea que hay capas caidas. Cualquier otro codigo
+# distinto de cero significa que se rompio el chequeador, que es otra cosa y tiene
+# que dejar el workflow en rojo.
+quit(status = if (nrow(caidas) > 0) 2L else 0L)

--- a/.github/workflows/chequeo-capas.yaml
+++ b/.github/workflows/chequeo-capas.yaml
@@ -1,0 +1,103 @@
+# Comprueba cada semana que los servicios de las capas del metadata sigan en pie,
+# y avisa por un issue cuando alguno deja de responder. La idea es enterarnos por
+# el repositorio y no porque a alguien se le rompa justo la capa que quería usar.
+name: chequeo-capas
+
+on:
+  schedule:
+    # Lunes a las 9:17 UTC, o sea 6:17 en Montevideo. El minuto 0 concentra la
+    # cola de trabajos de GitHub y el disparo se atrasa.
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+# El cron y un disparo manual a la vez podrían abrir dos issues.
+concurrency:
+  group: chequeo-capas
+  cancel-in-progress: false
+
+jobs:
+  chequeo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Solo R base: el chequeo lee data/metadata.rda y consulta con curl, así que
+      # no hace falta compilar sf ni instalar el paquete. Un fallo de instalación
+      # no es lo que este workflow quiere detectar.
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Consultar los servicios
+        id: chequeo
+        shell: bash
+        run: |
+          set +e
+          Rscript .github/scripts/chequeo-capas.R
+          rc=$?
+          set -e
+          echo "codigo=$rc" >> "$GITHUB_OUTPUT"
+          # 2 es el hallazgo esperado: hay capas caídas. Cualquier otro código
+          # distinto de cero significa que se rompió el chequeador, y eso sí tiene
+          # que dejar el workflow en rojo.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then exit "$rc"; fi
+
+      - name: Guardar el detalle
+        uses: actions/upload-artifact@v4
+        with:
+          name: chequeo-capas
+          retention-days: 30
+          path: |
+            chequeo-capas.md
+            chequeo-capas.rds
+            chequeo-capas.estado
+
+      # Un issue por vez, y sólo se comenta cuando cambia QUÉ está caído. Si no,
+      # con 30 capas caídas desde hace meses llegaría un comentario idéntico todos
+      # los lunes.
+      - name: Avisar si alguna capa no responde
+        if: steps.chequeo.outputs.codigo == '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          huella=$(sha256sum chequeo-capas.estado | cut -d' ' -f1)
+          cuerpo=$(mktemp)
+          cat chequeo-capas.md > "$cuerpo"
+          printf '\n<!-- huella:%s -->\n' "$huella" >> "$cuerpo"
+          numero=$(gh issue list --label "capas-caidas" --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -z "$numero" ]; then
+            gh label create "capas-caidas" --color B60205 --description "Capas cuyo servicio dejó de responder" 2>/dev/null || true
+            gh issue create --title "Hay capas que no responden" --label "capas-caidas" --body-file "$cuerpo"
+          elif gh issue view "$numero" --json body --jq .body | grep -qF "huella:$huella"; then
+            echo "Sigue igual que la semana pasada; no comento."
+          else
+            gh issue edit "$numero" --body-file "$cuerpo"
+            gh issue comment "$numero" --body "Cambió la lista de capas caídas. El detalle actualizado quedó arriba."
+          fi
+          # La label sobra mientras haya algo caído.
+          gh issue edit "$numero" --remove-label "recuperacion-pendiente" 2>/dev/null || true
+
+      # Se cierra recién con dos chequeos verdes seguidos, para no cerrar y reabrir
+      # ante un servicio que parpadea.
+      - name: Cerrar el aviso si ya está todo en pie
+        if: steps.chequeo.outputs.codigo == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          numero=$(gh issue list --label "capas-caidas" --state open --limit 1 --json number --jq '.[0].number // empty')
+          [ -z "$numero" ] && exit 0
+          if gh issue view "$numero" --json labels --jq '.labels[].name' | grep -qx "recuperacion-pendiente"; then
+            gh issue comment "$numero" --body "Segundo chequeo seguido con todas las capas respondiendo. Se cierra; si algo se cae de nuevo, el chequeo vuelve a abrir un aviso."
+            gh issue close "$numero"
+          else
+            gh label create "recuperacion-pendiente" --color 0E8A16 --description "Un chequeo verde; se cierra al segundo" 2>/dev/null || true
+            gh issue edit "$numero" --add-label "recuperacion-pendiente"
+            gh issue comment "$numero" --body "Todas las capas respondieron en este chequeo. Se cierra si el próximo también sale limpio."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ dev
 geouy.Rcheck/
 geouy*.tar.gz
 geouy*.tgz
+
+# Salida del chequeo semanal de capas
+chequeo-capas.md
+chequeo-capas.rds
+chequeo-capas.estado


### PR DESCRIPTION
Lo que pediste en el #22: que el repositorio avise cuando una capa deja de responder, en vez de enterarnos porque a alguien se le rompe justo la que quería usar.

Un workflow semanal, que también se dispara a mano, que recorre las 90 capas del metadata y abre o actualiza un issue con las que no contestan.

### Dos decisiones que tomé

**No usa el paquete ni `sf`.** Lee `data/metadata.rda` directo y consulta con `curl`. Así corre sin compilar el stack espacial y, sobre todo, no se cae por un problema de instalación — que no es lo que este workflow quiere detectar. La contra: esto es una prueba que dice si el servicio está y la capa existe, no que `sf` pueda leerla y transformarla.

**No baja las capas enteras.** Pide una sola feature por capa, y sólo la cabecera en los 17 zips que son archivos estáticos. Vos habías dicho de correr `load_geouy()` sobre todas, y lo pensé, pero serían gigabytes por semana contra servidores del Estado: CONEAT sola trae 237.681 polígonos y tarda cuatro minutos. Para la pregunta «¿el servicio está?» no hace falta. Si te parece, se puede agregar después un modo completo manual, para correr sobre las que fallaron.

### Lo que costó: un 200 no quiere decir que ande

Los geoserver contestan sus excepciones con **código 200** y un XML de error. Vi uno de 507 bytes y otro de 432, así que un umbral de tamaño deja pasar errores igual. El chequeo entonces mira si lo que llegó se parece a datos: una `FeatureCollection`, la firma `PK` de un zip, o un `WFS_Capabilities`.

Y eso encontró algo antes de estar mergeado.

### La capa «Zonas11» está rota, y no se podía notar

El metadata pide `INECenso2011:Zona_2011` y el geoserver publica `zona_2011`, en minúscula:

```
typeName pedido: INECenso2011:Zona_2011
respuesta:       HTTP 200, 432 bytes
                 <ServiceException code="InvalidParameterValue" locator="typeName">
```

Con el nombre correcto devuelve **69.752 zonas**. Lo dejé en un issue aparte porque es un arreglo del metadata y no de este workflow.

### Pensado para reducir el ruido

Hay un solo issue con label. Se comenta **únicamente cuando cambia qué está caído**: si no, con las capas que llevan meses abajo llegaría un comentario idéntico todos los lunes. Y se cierra recién con dos chequeos verdes seguidos, para no cerrar y reabrir ante un servicio que parpadea.

El código de salida separa los dos casos: `2` es «hay capas caídas» y deja el workflow verde con el issue abierto; cualquier otro código es «se rompió el chequeador» y lo deja en rojo, porque ahí el problema es nuestro.

### Cómo da hoy

Corriéndolo contra los servicios reales: **59 de 90 capas responden**. El detalle queda como artifact de cada corrida.

Una aclaración: `Municipios10`, `Municipios15` y `CONEAT` figuran caídas porque esta rama sale de `master` y no tiene los arreglos del #23. Cuando eso entre, se descuentan tres.
