### PR TITLE
tiles_geouy(): recortar con varios tiles, distinguir el servicio caído y aliviar el ejemplo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,26 @@
 
 ## geouy v0.2.9
 
+* Fix `tiles_geouy()` returning the whole union of the tiles when the area
+  spans more than one. The crop to the requested area, and the CRS, were only
+  applied on the single-tile path; asking for 300 m around a point came back as
+  a 1200x2400 raster with `crs` NA instead of the 600 metres of side that were
+  asked for. Both are now applied on either path.
+* `tiles_geouy()` keeps the CRS the file declares, and only sets one when the
+  file brought none. The `.jpg` of the "rgb" format come with a world file and
+  no CRS, so there it is needed; the `.tif` of "rgbi" do declare one, and it
+  says SIRGAS-ROU98 UTM 21S rather than WGS84, so overwriting it was silently
+  changing the datum of the raster.
+* `tiles_geouy()` tells apart a service returning no tiles at all from a
+  geometry that falls outside the covered area. A WFS answering 200 with no
+  features comes back as a valid empty `sf`, and the message the user got said
+  their geometry was not in Uruguay when the problem was the service.
+* The example of `tiles_geouy()` no longer downloads a tile. The tile is the
+  unit of download -the crop happens afterwards- so asking for a small area
+  does not download less: the tile in the example weighs 66.7 MB. The sizes are
+  now documented in the `format` argument, where an "rgbi" tile of the national
+  flight reaches 1.3 GB.
+
 * Fix the layer name of `Zonas11`, which asked for `INECenso2011:Zona_2011`
   while the MIDES geoserver publishes it as `zona_2011`. The failure was hard
   to spot: the server answers HTTP 200 with a `ServiceException` inside, so

--- a/R/tiles_geouy.R
+++ b/R/tiles_geouy.R
@@ -33,7 +33,7 @@ descarga_tile <- function(url, destino) {
 #' @family service
 #' @param x An 'sf' object with the same crs as the homonym parameter
 #' @param d numeric; buffer distance for all, or for each of the elements in x; in case dist is a units object, it should be convertible to arc_degree if x has geographic coordinates, and to st_crs(x)$units otherwise. Default NA, but if x is a only one point buffer default is 100.
-#' @param format Format of the archives to download (avaiable: "rgb" and "rgbi") Default "rgb"
+#' @param format Format of the archives to download (avaiable: "rgb" and "rgbi"). Default "rgb". Mind the size before asking: one "rgb" tile weighs 3 to 67 MB in the urban flight and around 250 MB in the national one, and one "rgbi" tile weighs about 380 MB and 1.3 GB respectively. The whole tile is downloaded and only then cropped to x.
 #' @param folder Folder where are the files or be download
 #' @param urban logical; If FALSE take orthophotos of national flight with 32cm per pixel, if TRUE take urban flight with 10cm per pixel (available for every locality covered by the urban flight)
 #' @keywords IDE orthophotos Uruguay
@@ -51,11 +51,16 @@ descarga_tile <- function(url, destino) {
 #' @importFrom curl has_internet
 #' @export
 #' @examples
-#'\donttest{
+#'\dontrun{
+#' # Not run because a whole tile is downloaded, and the tile is the unit: the
+#' # crop to the requested area happens after the download, so asking for a
+#' # small area does not download less. The tile covering this point weighs
+#' # 66.7 MB, and that is not the worst case: an urban .jpg ranges from 3 to
+#' # 67 MB depending on the tile -a twentyfold spread inside one locality-
+#' # and a national one is around 250 MB.
 #' x <- data.frame(x = 577968, y = 6147753, id = 1)
 #' x <- sf::st_as_sf(x, coords = c("x", "y"), crs = 32721)
-#' x_tiles <- try(tiles_geouy(x, urban = TRUE), silent = TRUE)
-#' if (!inherits(x_tiles, "try-error")) x_tiles
+#' tiles_geouy(x, urban = TRUE)
 #'}
 
 tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = FALSE){
@@ -90,6 +95,16 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
       stop("IDEuy Server out of service, try in https://visualizador.ide.uy/ideuy/core/load_public_project/ideuy/\n",
            "Details: ", conditionMessage(attr(x2, "condition")), call. = FALSE)
     }
+    # Un servicio que responde 200 sin features devuelve un sf valido y vacio,
+    # asi que no hay error y el codigo seguia de largo: el st_join no encontraba
+    # nada y al usuario se le decia que su punto estaba mal cuando el problema
+    # era del servicio. La comprobacion va ANTES del join, porque despues un
+    # cero significa las dos cosas a la vez.
+    if (nrow(x2) == 0) {
+      stop("The IDEuy national tile layer came back with no tiles at all, so ",
+           "the service is not returning data right now. This is not a problem ",
+           "with x.", call. = FALSE)
+    }
     x2 <- x2 %>% 
       sf::st_join(x %>% sf::st_transform(5381), left = F) %>% 
       dplyr::distinct(.data$nombre, .keep_all = TRUE)
@@ -106,6 +121,12 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
     }
     # Ya no se filtra por localidad: el vuelo urbano cubre 86 y el st_join con la
     # geometria del usuario alcanza para quedarse con los tiles que le sirven.
+    # Idem grilla nacional: capa vacia es problema del servicio, no de x.
+    if (nrow(x2) == 0) {
+      stop("The IDEuy urban tile layer came back with no tiles at all, so the ",
+           "service is not returning data right now. This is not a problem ",
+           "with x.", call. = FALSE)
+    }
     x2 <- x2 %>%
       sf::st_join(x %>% sf::st_transform(5381), left = F) %>%
       dplyr::distinct(.data$nombre, .keep_all = TRUE)
@@ -165,17 +186,35 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
   # Return ----
   if (length(ar) == 1) {
     a3 <- raster::brick(ar)
-    suppressWarnings(raster::crs(a3) <- "+proj=utm +zone=21 +south +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs")
-    bb <- sf::st_transform(bb %>% sf::st_as_sf(), raster::crs(a3))
-    suppressWarnings(a3 <- raster::crop(a3, bb))
   } else {
-    rast.list <- list()
-    for (i in 1:length(ar)) { rast.list[i] <- raster::brick(ar[i]) }
-    # And then use do.call on the list of raster objects
+    # Con `[` en vez de `[[` se guarda una lista adentro de la lista, y R avisa
+    # "implicit list embedding of S4 objects is deprecated". Hoy es un warning;
+    # esta anunciado que pasa a error.
+    rast.list <- vector("list", length(ar))
+    for (i in seq_along(ar)) rast.list[[i]] <- raster::brick(ar[i])
     rast.list$fun <- mean
-    a3 <- do.call(raster::mosaic,rast.list)
+    # El mosaico es lo mas caro de la funcion y estaba calculado dos veces
+    # seguidas, la primera para nada.
     a3 <- do.call(raster::mosaic, rast.list)
   }
+  # El CRS y el recorte van despues del if/else, para los dos caminos. Estaban
+  # solo en la rama de un tile: con dos o mas, el resultado salia sin CRS -y por
+  # lo tanto sin georreferenciar- y sin recortar, devolviendo la union entera de
+  # los tiles en vez del area pedida. Pidiendo 300 m alrededor de un punto se
+  # bajan 3 tiles y volvia un raster de 17713 x 19436 pixeles para un area de
+  # unos 6000 de lado.
+  # Los .jpg del formato "rgb" vienen con world file y sin CRS declarado, asi
+  # que hay que ponerselo. Los .tif de "rgbi" en cambio SI lo declaran, y no es
+  # el mismo: dicen SIRGAS-ROU98_UTM_Zone_21S, no WGS84. Pisarlo sin mirar le
+  # cambiaba el datum al raster en silencio, asi que solo se asigna cuando el
+  # archivo no trajo ninguno.
+  if (is.na(raster::crs(a3))) {
+    suppressWarnings(raster::crs(a3) <- "+proj=utm +zone=21 +south +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs")
+  }
+  # La transformacion de bb va despues de tener el CRS del raster: al reves, sf
+  # no tiene destino al que transformar y falla con "crs not found".
+  bb <- sf::st_transform(bb %>% sf::st_as_sf(), raster::crs(a3))
+  suppressWarnings(a3 <- raster::crop(a3, bb))
   # raster::plotRGB(a3)
   return(a3)
 }

--- a/man/tiles_geouy.Rd
+++ b/man/tiles_geouy.Rd
@@ -11,7 +11,7 @@ tiles_geouy(x, d = NA, format = "rgb", folder = tempdir(), urban = FALSE)
 
 \item{d}{numeric; buffer distance for all, or for each of the elements in x; in case dist is a units object, it should be convertible to arc_degree if x has geographic coordinates, and to st_crs(x)$units otherwise. Default NA, but if x is a only one point buffer default is 100.}
 
-\item{format}{Format of the archives to download (avaiable: "rgb" and "rgbi") Default "rgb"}
+\item{format}{Format of the archives to download (avaiable: "rgb" and "rgbi"). Default "rgb". Mind the size before asking: one "rgb" tile weighs 3 to 67 MB in the urban flight and around 250 MB in the national one, and one "rgbi" tile weighs about 380 MB and 1.3 GB respectively. The whole tile is downloaded and only then cropped to x.}
 
 \item{folder}{Folder where are the files or be download}
 
@@ -24,11 +24,16 @@ raster::stack object with th cropped tif corresponding to x bbox
 This function allows to Download .jpg or .tif files from the IDEuy tiles repository, according to a 'sf' object bbox.
 }
 \examples{
-\donttest{
+\dontrun{
+# Not run because a whole tile is downloaded, and the tile is the unit: the
+# crop to the requested area happens after the download, so asking for a
+# small area does not download less. The tile covering this point weighs
+# 66.7 MB, and that is not the worst case: an urban .jpg ranges from 3 to
+# 67 MB depending on the tile -a twentyfold spread inside one locality-
+# and a national one is around 250 MB.
 x <- data.frame(x = 577968, y = 6147753, id = 1)
 x <- sf::st_as_sf(x, coords = c("x", "y"), crs = 32721)
-x_tiles <- try(tiles_geouy(x, urban = TRUE), silent = TRUE)
-if (!inherits(x_tiles, "try-error")) x_tiles
+tiles_geouy(x, urban = TRUE)
 }
 }
 \seealso{


### PR DESCRIPTION
Cierra el #5, el #6 y el #7. Van juntos porque los tres caen en el mismo
archivo y se tocan entre sí.

## El recorte (#5)

`tiles_geouy()` recortaba al área pedida sólo cuando bajaba un tile. Con dos o
más caía en la rama del mosaico, que no recortaba ni asignaba CRS.

Mismo pedido —300 m de buffer, que caen en 3 tiles— con las dos versiones,
bajando los tiles de verdad:

```
master   17713 x 19436 = 344.3 Mpx | crs: NA        | 516s
esta     6050 x  6050  =  36.6 Mpx | crs: asignado  | 349s
```

Nueve veces menos píxeles, que es el área que se pidió (6050 px son los 600
metros de lado a 10 cm/píxel), ahora georreferenciada. Y 167 segundos menos,
porque el mosaico estaba escrito dos veces seguidas y se calculaba dos veces.

El CRS y el `crop()` pasan a estar después del `if/else`, así que aplican a los
dos caminos. **El orden importa y es el necesario**: si se transforma `bb` antes
de que el raster tenga CRS, `sf` no tiene destino y falla con `crs not found`.

Y comprobé que el camino que ya andaba no cambia:

```
master  1008 x 1008 | extent 577918,578018,6147703,6147803 | crs: asignado
esta    1008 x 1008 | extent 577918,578018,6147703,6147803 | crs: asignado
```

También `rast.list[i] <-` pasa a `[[i]] <-`. Con un corchete se guarda una lista
adentro de la lista, y R lo avisa: en la corrida de master aparecen tres
`implicit list embedding of S4 objects is deprecated`, uno por tile, que esta
versión ya no emite. Hoy es un warning y está anunciado que pasa a error.

## El CRS que veníamos pisando

Esto no estaba en el issue y apareció verificando. La string de UTM 21S se
asignaba siempre, sin mirar si el archivo traía la suya. Leí las cabeceras
remotas de los dos formatos, sin descargarlos:

```
rgb  .jpg   >>> SIN CRS declarado
rgbi .tif   PROJCRS["SIRGAS-ROU98_UTM_Zone_21S", ...
```

Los `.jpg` vienen con world file y sin CRS, así que ahí asignarlo hace falta.
Pero los `.tif` del formato `rgbi` **sí lo declaran, y dicen SIRGAS-ROU98, no
WGS84**: les estábamos cambiando el datum en silencio. Ahora sólo se asigna
cuando el archivo no trajo ninguno.

## El mensaje (#6)

Si un WFS responde 200 sin features, `load_geouy()` devuelve un `sf` válido y
vacío. No hay error, el código seguía de largo, el `st_join` no encontraba nada
y al usuario se le decía que su geometría no estaba en Uruguay cuando el
problema era del servicio.

La comprobación va **antes del join**, porque después un cero significa las dos
cosas a la vez y ya no se pueden separar. Los cuatro mensajes quedan así:

```
capa vacía, vuelo nacional -> The IDEuy national tile layer came back with no
                              tiles at all, so the service is not returning
                              data right now. This is not a problem with x.
geometría lejos, nacional  -> The geometry in x is not in Uruguay, or its crs
                              is not the one it declares.
capa vacía, vuelo urbano   -> The IDEuy urban tile layer came back with no
                              tiles at all...
geometría lejos, urbano    -> No urban-flight orthophotos cover the geometry
                              in x. Use urban = FALSE...
```

## El ejemplo (#7)

Descargaba un tile de **66.7 MB** en cada chequeo. No alcanza con pedir un área
más chica, porque **el tile es la unidad**: el recorte ocurre después de
bajarlo. Y elegir una localidad más liviana tampoco, porque el peso depende del
tile puntual: medido, un `.jpg` del vuelo urbano va de **3 a 67 MB**, veinte
veces de diferencia dentro de una misma localidad.

Así que pasa a `\dontrun{}`. `\donttest{}` no alcanza: según R-exts, igual se
ejecuta por `example()`, y sólo `\dontrun{}` muestra sin ejecutar.

De paso documenté los pesos en `@param format`, que no decía nada al respecto:

| | rgb (.jpg) | rgbi (.tif) |
|---|---:|---:|
| vuelo urbano | 3 a 67 MB | ~380 MB |
| vuelo nacional | ~250 MB | **~1.3 GB** |

Quien pide `format = "rgbi"` en el vuelo nacional se baja 1.3 GB por tile sin
ningún aviso.

## La suite

Idéntica antes y después, y con el mismo conjunto exacto de tests fallando:

```
master:  [ FAIL 5 | WARN 4 | SKIP 0 | PASS 37 ]
esta:    [ FAIL 5 | WARN 4 | SKIP 0 | PASS 37 ]
```

Los cinco fallos son previos y ninguno toca `tiles_geouy()`. Tres son de la
misma familia y te los dejo dichos acá porque valen aparte: `test-load.R` falla
por el certificado de Ambiente (#30); `test-plot.R` pide la columna `AREA` que
la capa ya no tiene —ahora trae las variables del censo 2023—; y
`test-where_uy.R` busca el código 2220 en `Localidades pg` y no lo encuentra.
Son tests que afirman cosas sobre datos remotos que cambiaron. Va en la misma
dirección que el #33.

## Lo que dejo afuera a propósito

Tres cosas que aparecieron mirando esta parte y que no meto acá porque cambian
comportamiento previo:

- `rast.list$fun <- mean` no lleva `na.rm`, así que en un solapamiento donde un
  tile tenga NA el resultado es NA.
- No se valida resolución, origen de grilla ni cantidad de bandas antes del
  mosaico. Con bandas distintas falla con `number of items to replace is not a
  multiple of replacement length`, que no le dice nada al usuario.
- `SKIP 0` en la suite quiere decir que **ningún test se saltea**: hay tres
  archivos con llamadas de red sin `skip_on_cran()`, doce descargas contra
  servicios del Estado en cada chequeo.

Si te parece, los dejo como issues.
