### PR TITLE
La suite vuelve a pasar: cuatro tests afirmaban datos de capas que cambiaron

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,17 @@
   does not download less: the tile in the example weighs 66.7 MB. The sizes are
   now documented in the `format` argument, where an "rgbi" tile of the national
   flight reaches 1.3 GB.
+* The test suite passes again. Four tests asserted values from remote layers
+  that changed: `test-plot.R` and `test-which.R` named columns of `Secciones`
+  that the 2023 census replaced, `test-where_uy.R` looked up a locality code
+  that no longer exists, and `test-load.R` downloaded a layer from the Ambiente
+  server, which cannot be read at all. They now assert what each function
+  promises -an `sf` back, the columns it adds, one row per input- instead of
+  the schema of a service we do not control.
+* Two test blocks that reach the network gained `skip_if_offline()`, which also
+  covers `skip_on_cran()`. Every example was already inside `\donttest{}` or
+  `\dontrun{}`, and the vignette does not evaluate its chunks.
+
 * Fix `Localidades pt` returning polygons. Both `Localidades` rows asked the
   server for the same layer, `INECenso:Localidades_pg`, so the one meant to be
   points quietly returned the polygons. The server does publish

--- a/tests/testthat/test-add_geom.R
+++ b/tests/testthat/test-add_geom.R
@@ -1,4 +1,9 @@
 test_that("add_geom works", {
+  # add_geom() baja la capa de la unidad pedida, asi que sale a la red.
+  # skip_if_offline() llama a skip_on_cran() de entrada, y ademas cubre el caso
+  # de estar sin conexion, que skip_on_cran() solo no atrapa.
+  skip_if_offline()
+
   pobre_x_dpto <- as.data.frame(cbind(nomdpto = c("ARTIGAS", "DURAZNO", "FLORIDA", "LAVALLEJA"),
                         Pobreza = c(0.26, 0.27, 0.07, 0.10)))
   pobre_x_dpto_geo <- add_geom(data = pobre_x_dpto, unit = "Deptos", variable = "nomdpto")

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -4,8 +4,13 @@ test_that("connections working", {
   skip_if_offline()
   skip_on_cran()
   
+  # Una capa de cada rama de load_geouy(): "Secciones" viene por WFS y "Deptos"
+  # por zip. Antes la del zip salia del servidor de Ambiente, que no manda la
+  # cadena de certificados: ninguna herramienta que los verifique puede entrar,
+  # asi que el test fallaba por algo ajeno al paquete y ademas no cubria lo que
+  # queria cubrir.
   testthat::expect_is(load_geouy("Secciones"), "sf")
-  testthat::expect_is(load_geouy("Playas"), "sf")
+  testthat::expect_is(load_geouy("Deptos"), "sf")
   # testthat::expect_is(load_geouy("Centros poblados pg"), "sf")
 })
 
@@ -13,8 +18,8 @@ test_that("crs parameter working", {
   skip_if_offline()
   skip_on_cran()
   
-  testthat::expect_error(load_geouy("Playas", folder = 1))
-  testthat::expect_error(load_geouy("Playas", folder = c("c://", "c://")))
+  testthat::expect_error(load_geouy("Deptos", folder = 1))
+  testthat::expect_error(load_geouy("Deptos", folder = c("c://", "c://")))
   
   a <- load_geouy("Secciones", crs = 4326)
   a1 <- sf::st_crs(a)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -4,15 +4,22 @@ test_that("output is a ggplot", {
   skip_if_offline()
   
   secc <- load_geouy("Secciones")
-  aaa <- plot_geouy(x = secc, col = "AREA")  
+  # El test pedia la columna "AREA", que la capa dejo de traer cuando se
+  # republico con el censo 2023. En vez de cambiarla por otro nombre fijo -que
+  # va a quedar viejo igual la proxima vez- se toma la primera columna numerica
+  # que la capa traiga: lo que se esta probando es que plot_geouy() devuelva un
+  # ggplot con una variable continua, no como se llama esa variable.
+  num <- names(secc)[vapply(sf::st_drop_geometry(secc), is.numeric, logical(1))][1]
+  testthat::expect_false(is.na(num))
+  aaa <- plot_geouy(x = secc, col = num)  
   testthat::expect_is(aaa, "ggplot")
-  aaa <- plot_geouy(x = secc, col = "AREA", l = "%")  
+  aaa <- plot_geouy(x = secc, col = num, l = "%")  
   testthat::expect_is(aaa, "ggplot")
-  aaa <- plot_geouy(x = secc, col = "AREA", l = "n")  
+  aaa <- plot_geouy(x = secc, col = num, l = "n")  
   testthat::expect_is(aaa, "ggplot")
-  aaa <- plot_geouy(x = secc, col = "AREA", l = "c", other_lab = "CODSEC")  
+  aaa <- plot_geouy(x = secc, col = num, l = "c", other_lab = "CODSEC")  
   testthat::expect_is(aaa, "ggplot")
-  expect_error(plot_geouy(x = secc, col = "AREA", l = "c", other_lab = "zapallitos"))
+  expect_error(plot_geouy(x = secc, col = num, l = "c", other_lab = "zapallitos"))
   
   pobre_x_dpto <- structure(list(nomdpto = c("ARTIGAS", "DURAZNO", "FLORIDA", "LAVALLEJA", "MONTEVIDEO", "PAYSANDU", "SALTO"), 
                                  pobre06 = structure(c(2L, 2L, 2L, 2L, 2L, 2L, 2L), .Label = c("No pobre", "Pobre"), class = "factor"), 
@@ -39,6 +46,7 @@ test_that("Plot uses correct data", {
   skip_if_offline()
   
   secc <- load_geouy("Secciones")
-  p <- plot_geouy(secc, col = "AREA")
+  num <- names(secc)[vapply(sf::st_drop_geometry(secc), is.numeric, logical(1))][1]
+  p <- plot_geouy(secc, col = num)
   testthat::expect_equal(secc, p$data)
 })

--- a/tests/testthat/test-where_uy.R
+++ b/tests/testthat/test-where_uy.R
@@ -1,8 +1,30 @@
-test_that("multiplication works", {
-  expect_equal(nrow(where_uy(c = "Localidades pg", d = "cod", e = 2220)), 1)
-  expect_warning(where_uy(c = "Localidades pg", d = "cod", e = c(1220, 2220)))
+test_that("where_uy filtra por codigo y por nombre", {
+  skip_if_offline()
+
+  # El test buscaba el codigo 2220, que la capa dejo de traer cuando se
+  # republico con el censo 2023. Un valor puntual de un servicio ajeno queda
+  # viejo sin que nadie se entere, asi que ahora se toma un codigo real de la
+  # propia capa y se comprueba el comportamiento, que es lo que la funcion
+  # promete: devolver la fila del codigo pedido.
+  loc <- load_geouy("Localidades pg")
+  cod <- loc$CODLOC[[1]]
+  nom <- as.character(loc$NOMBLOC[[1]])
+
+  una <- where_uy(c = "Localidades pg", d = "cod", e = cod)
+  expect_s3_class(una, "sf")
+  expect_equal(nrow(una), 1)
+  expect_equal(una$CODLOC[[1]], cod)
+
+  expect_equal(nrow(where_uy(c = "Localidades pg", d = "name", e = nom)), 1)
+
+  # Dos codigos, uno de ellos inexistente: avisa que hubo menos coincidencias.
+  inexistente <- max(loc$CODLOC) + 1
+  expect_warning(where_uy(c = "Localidades pg", d = "cod", e = c(cod, inexistente)))
+
+  # Un codigo que no existe no devuelve nada, y lo dice.
+  expect_error(where_uy(c = "Localidades pg", d = "cod", e = inexistente))
+
+  # Los tipos tienen que corresponderse con lo que se pide.
   expect_warning(expect_error(where_uy(c = "Localidades pg", d = "cod", e = "c")))
   expect_error(where_uy(c = "Localidades pg", d = "name", e = 1))
-  expect_equal(nrow(where_uy(c = "Peajes", d = "name", e = "Pando")), 1)
-  expect_error(where_uy(c = "Localidades pg", d = "cod", e = 1220))
 })

--- a/tests/testthat/test-which.R
+++ b/tests/testthat/test-which.R
@@ -10,7 +10,16 @@ test_that("crs parameter working", {
   a1 <- sf::st_crs(b)
   testthat::expect_equal(a1[1], list(input = "EPSG:32721"))
   testthat::expect_is(b, "sf")
-  testthat::expect_equal(names(c), c("gml_id", "nombre", "operador", "depto", "cod_Departamentos", 
-                           "name_Departamentos", "full_Secciones", "AREA", "PERIMETER", 
-                           "DEPTO", "SECCION", "CODSEC", "NOMBDEPTO", "CDEPTO_ISO", "geom"))
+  # El test fijaba los quince nombres de columna que salian del cruce, y tres de
+  # ellos -AREA, PERIMETER y CDEPTO_ISO- desaparecieron cuando el INE republico
+  # la capa con el censo 2023, que trajo en cambio viv_tot_23 y las tres de
+  # poblacion. Fijar la lista entera ata el test al esquema de un organismo que
+  # puede cambiarlo cuando quiera, y ademas no es lo que la funcion promete.
+  # Lo que which_uy() promete es conservar las columnas de x y agregarle una por
+  # cada unidad consultada, asi que eso es lo que se comprueba.
+  testthat::expect_is(c, "sf")
+  testthat::expect_true(all(names(a) %in% names(c)))
+  testthat::expect_true(all(c("cod_Departamentos", "name_Departamentos",
+                              "full_Secciones") %in% names(c)))
+  testthat::expect_equal(nrow(c), nrow(a))
 })


### PR DESCRIPTION
Cierra el #38. La suite vuelve a pasar entera.

```
antes:   [ FAIL 5 | WARN 4 | SKIP 0 | PASS 37 ]
ahora:   [ FAIL 0 | WARN 3 | SKIP 0 | PASS 59 ]
```

## Los tests estaban afirmando cosas sobre datos de otros

Cuatro tests fallaban, y ninguno por un problema del paquete: todos afirmaban
valores de capas remotas que cambiaron.

| Test | Qué afirmaba | Qué pasó |
|---|---|---|
| `test-plot.R` | la columna `AREA` de `Secciones` | el INE republicó con el censo 2023 |
| `test-which.R` | quince nombres de columna exactos | ahora son diecisiete |
| `test-where_uy.R` | el código `2220` de `Localidades pg` | ya no existe |
| `test-load.R` | bajar `Playas` | es del servidor de Ambiente (#30) |

En el caso de `Secciones`, lo que se fue fueron `AREA`, `PERIMETER` y
`CDEPTO_ISO`, y llegaron `id`, `viv_tot_23`, `pob_tot_23`, `pob_tot_hom_23` y
`pob_tot_muj_23`.

## Por qué no les cambié el valor y ya

Porque los dejaba igual de frágiles. La próxima vez que el INE republique
vuelven a fallar, y otra vez nos vamos a enterar meses después.

Así que ahora cada test comprueba **lo que la función promete**, no el esquema
de un servicio que no controlamos:

- `plot_geouy()` toma la primera columna numérica que la capa traiga. Lo que se
  prueba es que devuelva un ggplot para una variable continua, no cómo se llama
  esa variable.
- `where_uy()` toma un código real de la propia capa y comprueba que devuelva
  esa fila. También el caso de un código inexistente y el de tipos cruzados.
- `which_uy()` comprueba que conserve las columnas de `x`, que agregue una por
  unidad consultada -`cod_Departamentos`, `name_Departamentos`,
  `full_Secciones`- y que no cambie la cantidad de filas. Eso es su contrato;
  las columnas de `Secciones` son del INE.
- El de la rama zip pasa de `Playas` a `Deptos`, que también es zip pero de un
  servidor que responde. Sigue cubriendo las dos ramas de `load_geouy()`.

No fui por fixtures grabados: las capas son de decenas de miles de geometrías,
inflan el paquete, y quedan viejas en silencio, que es justo el problema que
estamos tratando de resolver.

## Los skips, y una corrección sobre CRAN

Dos bloques salían a la red sin ninguno: `test-add_geom.R` y `test-where_uy.R`,
ocho llamadas entre los dos. Les puse `skip_if_offline()`, que es mejor que
`skip_on_cran()` a secas: hace lo mismo -lo llama de entrada- y además cubre el
caso de estar sin conexión. `curl` ya está en Imports, así que no agrega
dependencia.

**Pero tengo que corregir el motivo que le había puesto.** Yo escribí que eran
descargas contra servicios del Estado «en cada chequeo de CRAN». Fui a
comprobarlo y no es así: `.Rbuildignore` tiene `^tests$`, así que **el paquete
se construye sin los tests**. Lo verifiqué armando el tarball:

```
tar tzf geouy_0.2.9.tar.gz | grep -c "^geouy/tests/"
0
```

O sea que los tests no viajan en el paquete y CRAN nunca los corre. Los skips
siguen valiendo -para quien corra la suite sin conexión, y para el día que
quieras que el CI la corra- pero no por el motivo que yo había dado.

Los ejemplos y la viñeta sí llegan a CRAN, y los dos ya estaban cubiertos:
**todos** los ejemplos de `man/` están dentro de `\donttest{}` o `\dontrun{}`, y
la viñeta tiene `eval = FALSE` global y en cada chunk.

Y queda una pregunta que te dejo, porque es tuya: **¿querés que los tests viajen
en el paquete?** Hoy no van, así que ni CRAN ni quien instale desde el tarball
puede verificar que el paquete funciona. Sacar `^tests$` los haría viajar, pero
entonces sí importaría todo lo de los skips y habría que mirarlo con cuidado.

## Los tres warnings que quedan

Dos son esperables: son del test que valida un `folder` inválido, donde
`normalizePath()` avisa antes de que salte el error que el test espera.

El tercero **es un defecto real del paquete** y lo dejo en un issue aparte:

```
test-add_geom.R:9:3
Using an external vector in selections was deprecated in tidyselect 1.1.0.
ℹ Please use `all_of()` or `any_of()` instead.
```

Viene de `R/add_geom.R`, no del test, y es una deprecación anunciada que en
algún momento pasa a error.

## Una corrección mía

El issue #38 original decía «doce llamadas de red en tres archivos sin
`skip_on_cran()`» y que `SKIP 0` probaba que nada se saltea en CRAN. Las dos
cosas estaban mal y ya las corregí ahí: `skip_if_offline()` **ya llama** a
`skip_on_cran()`, así que dos de esos archivos estaban protegidos; y
`devtools::test()` define `NOT_CRAN=true`, con lo cual una corrida local nunca
muestra esos skips.

