### PR TITLE
El mosaico de tiles_geouy() puede devolver bandas inventadas sin avisar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,16 @@
   does not download less: the tile in the example weighs 66.7 MB. The sizes are
   now documented in the `format` argument, where an "rgbi" tile of the national
   flight reaches 1.3 GB.
+* `tiles_geouy()` checks that the tiles can be mosaicked before trying. The
+  dangerous case is the number of bands: `raster::mosaic()` does not reject it,
+  it takes the maximum and recycles the tile that has fewer, so a one-band tile
+  next to a three-band one comes back as three bands with the single one
+  repeated -a raster carrying made-up values, with no warning at all. When the
+  counts are not divisors of each other the error does exist, but reads
+  "number of items to replace is not a multiple of replacement length", which
+  names neither the tile nor the layer. Resolution, grid origin and CRS are
+  checked too, and the message now says which tile differs and in what.
+
 * Fix `Localidades pt` returning polygons. Both `Localidades` rows asked the
   server for the same layer, `INECenso:Localidades_pg`, so the one meant to be
   points quietly returned the polygons. The server does publish

--- a/R/tiles_geouy.R
+++ b/R/tiles_geouy.R
@@ -29,6 +29,35 @@ descarga_tile <- function(url, destino) {
   invisible(destino)
 }
 
+# Los tiles de un mosaico tienen que compartir cantidad de bandas, resolucion,
+# origen de grilla y CRS. Se compara cada uno contra el primero, que es lo que
+# hace raster::mosaic() por dentro: no hace falta compararlos todos entre si.
+incompatible_o_falla <- function(primero, otro, nombre_primero, nombre_otro) {
+  redondear <- function(x) round(x, 9)
+  difs <- character()
+  if (raster::nlayers(primero) != raster::nlayers(otro)) {
+    difs <- c(difs, glue::glue("bands: {raster::nlayers(primero)} vs {raster::nlayers(otro)}"))
+  }
+  if (!isTRUE(all.equal(redondear(raster::res(primero)), redondear(raster::res(otro))))) {
+    difs <- c(difs, glue::glue("resolution: {paste(raster::res(primero), collapse = 'x')} vs ",
+                               "{paste(raster::res(otro), collapse = 'x')}"))
+  }
+  if (!isTRUE(all.equal(redondear(raster::origin(primero)), redondear(raster::origin(otro))))) {
+    difs <- c(difs, glue::glue("grid origin: {paste(round(raster::origin(primero), 3), collapse = ',')} vs ",
+                               "{paste(round(raster::origin(otro), 3), collapse = ',')}"))
+  }
+  crs_primero <- as.character(raster::crs(primero))
+  crs_otro <- as.character(raster::crs(otro))
+  if (!identical(crs_primero, crs_otro)) {
+    difs <- c(difs, "coordinate reference system")
+  }
+  if (length(difs) == 0) return(invisible(TRUE))
+  stop(glue::glue("The tiles cannot be mosaicked together: '{nombre_otro}' differs ",
+                  "from '{nombre_primero}' in {paste(difs, collapse = '; ')}. ",
+                  "This is a problem with the IDEuy tiles, not with x. ",
+                  "Please report it."), call. = FALSE)
+}
+
 #' This function allows to Download .jpg or .tif files from the IDEuy tiles repository, according to a 'sf' object bbox.
 #' @family service
 #' @param x An 'sf' object with the same crs as the homonym parameter
@@ -191,7 +220,21 @@ tiles_geouy <- function(x, d = NA, format = "rgb", folder = tempdir(), urban = F
     # "implicit list embedding of S4 objects is deprecated". Hoy es un warning;
     # esta anunciado que pasa a error.
     rast.list <- vector("list", length(ar))
-    for (i in seq_along(ar)) rast.list[[i]] <- raster::brick(ar[i])
+    for (i in seq_along(ar)) {
+      rast.list[[i]] <- raster::brick(ar[i])
+      # raster::mosaic() no comprueba que los tiles sean combinables, y el caso
+      # peligroso es la cantidad de bandas: no da error, calcula el maximo y
+      # RECICLA el que tiene menos. Un tile de una banda junto a otro de tres
+      # vuelve como tres bandas, con la unica repetida en las tres -o sea, un
+      # raster con datos inventados y sin un solo aviso-. Cuando las cantidades
+      # no son divisores entre si el error existe pero no dice nada: "number of
+      # items to replace is not a multiple of replacement length".
+      # La resolucion, el origen de grilla y el CRS si los rechaza, pero con
+      # mensajes que tampoco nombran al tile. Comprobar es gratis: brick() lee
+      # la cabecera y no los pixeles, unos milisegundos por archivo.
+      if (i > 1) incompatible_o_falla(rast.list[[1]], rast.list[[i]],
+                                      basename(ar[1]), basename(ar[i]))
+    }
     rast.list$fun <- mean
     # El mosaico es lo mas caro de la funcion y estaba calculado dos veces
     # seguidas, la primera para nada.


### PR DESCRIPTION
Cierra el #37, y el problema resultó más serio de lo que yo había escrito ahí.

## No es sólo que el mensaje sea malo

Cuando abrí el issue dije que `raster::mosaic()` no valida nada y que el error
es incomprensible. Lo segundo es cierto, pero lo primero se queda corto:
**con distinta cantidad de bandas no da error**. Toma el máximo y **recicla** el
tile que tiene menos.

Medido con dos rasters, uno de una banda y otro de tres:

```
banda 1: 11, 11, 21, 21
banda 2: 11, 11, 22, 22
banda 3: 11, 11, 23, 23
```

El de una banda se repitió en las tres. Devuelve un raster con valores
inventados, sin error y sin warning. Es la misma familia de fallas que veníamos
persiguiendo: la peor no es la que corta, es la que devuelve algo plausible.

Cuando las cantidades no son divisores entre sí el error sí aparece, pero es
este:

```
number of items to replace is not a multiple of replacement length
```

No menciona tiles, ni bandas, ni de qué capa se trata.

## Qué comprueba ahora

Cada tile contra el primero -que es lo que `mosaic()` hace por dentro, así que
no hace falta compararlos todos entre sí-: cantidad de bandas, resolución,
origen de grilla y CRS. El mensaje dice cuál difiere y en qué:

```
The tiles cannot be mosaicked together: 'tile_B.jpg' differs from 'tile_A.jpg'
in bands: 1 vs 3. This is a problem with the IDEuy tiles, not with x.
Please report it.
```

## Cuesta nada

`raster::brick()` lee la cabecera, no los píxeles: **9 milésimas de segundo y
14 KB** por archivo, y `inMemory()` da FALSE. Comparar `nlayers()`, `res()`,
`origin()` y `crs()` no toca el disco.

## Probado

Control positivo, los cinco casos incompatibles:

```
1 banda vs 3           CORTA: ... in bands: 1 vs 3
2 bandas vs 3          CORTA: ... in bands: 2 vs 3
resolución distinta    CORTA: ... in resolution: 1x1 vs 0.5x0.5
CRS distinto           CORTA: ... in coordinate reference system
origen distinto        CORTA: ... in grid origin: 0,0 vs 0.5,0
```

Verificación por rotura, que es lo que hace que la prueba pruebe algo: dos tiles
compatibles **no** cortan, y el mosaico de esos dos sigue devolviendo sus tres
bandas con la extensión unida.

## ¿Hace falta, si hoy no pasa?

Es la pregunta justa, y me la hice antes de escribirlo. Hoy los tiles de la IDE
son homogéneos: los que muestreé tienen tres bandas, resolución 0.32 y grilla
compatible. Así que esto no se dispara.

Pero la capa tiene **6597 tiles de doce remesas distintas**, y hay tiles
contiguos que son de remesas distintas, así que una consulta puede cruzar dos
sin problema. Si alguna vez una remesa sale con otro perfil, o un archivo baja
defectuoso, la diferencia es entre un error que se entiende y un raster con
datos que nadie pidió.

Son quince líneas y no tocan el camino feliz.

## Aparte: cerré el #36, que estaba mal

Mientras miraba esto encontré que el issue que abrí sobre `fun = mean` sin
`na.rm` **era falso**: `mosaic()` le pasa `na.rm = TRUE` a la función por
dentro. Y el arreglo que yo proponía ahí rompía la función. Está explicado en
el #36.
