### PR TITLE
El chequeo semanal ahora también comprueba que el metadata diga la verdad

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 ^chequeo-capas\.md$
 ^chequeo-capas\.rds$
 ^chequeo-capas\.estado$
+^\.gitattributes$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# NEWS.md acumula lineas: cuando dos ramas agregan la suya en el mismo punto, no
+# hay nada que elegir entre una y otra, van las dos. Con merge=union git las deja
+# a las dos en vez de marcar un conflicto que despues se resuelve siempre igual.
+# Probado: sin esto, dos ramas que agregan al principio chocan; con esto, no.
+NEWS.md merge=union
+
+# Los datos del paquete son binarios generados por data-raw/metadata.R. Git no
+# los puede fusionar y no hay que intentarlo: cuando dos ramas los tocan, la
+# salida es REGENERARLOS desde ese archivo -que si se fusiona solo, porque es
+# texto- y no elegir una de las dos versiones. Marcarlos como binarios evita
+# ademas que git intente un merge por lineas sobre bytes comprimidos.
+*.rda binary
+*.Rds binary
+*.rds binary

--- a/.github/scripts/chequeo-capas.R
+++ b/.github/scripts/chequeo-capas.R
@@ -30,16 +30,7 @@ acotar <- function(url) {
   }
 }
 
-endpoint <- function(url, repositor) {
-  # Las capas del SGM no traen URL: el campo guarda el nombre de la capa y la URL
-  # la arma load_geouy(). Se pide la capa concreta y no el GetCapabilities, porque
-  # si no las tres darian OK con que el servidor este vivo.
-  if (identical(repositor, "SGM")) {
-    return(paste0("http://geoservicios.sgm.gub.uy/wfsPCN1000.cgi",
-                  "?service=WFS&version=1.0.0&request=GetFeature",
-                  "&typeName=", utils::URLencode(url, reserved = TRUE),
-                  "&maxFeatures=1"))
-  }
+endpoint <- function(url) {
   url <- sub("^WFS:", "", url)
   if (!grepl("^https?://", url, ignore.case = TRUE)) {
     return(NA_character_)
@@ -91,10 +82,51 @@ clasificar <- function(r, solo_cabecera) {
   "respondio algo que no son datos"
 }
 
+# El servicio puede responder perfecto y la ficha estar mintiendo igual: si el
+# cod o el name que declara no existen en la capa, where_uy() falla con "Can't
+# extract columns that don't exist". Nos paso con diez capas, y todas menos las
+# ultimas seis apareceron de casualidad mirando otra cosa.
+#
+# Se pregunta por DescribeFeatureType y no por una feature: devuelve el esquema
+# sin datos, 1.7 KB contra 210 KB, y da los nombres en atributos name="...".
+# Buscar el nombre de la columna adentro del cuerpo de una feature no sirve:
+# "depto" matchea dentro de "coddepto", el nombre de la capa aparece en la URL
+# que el propio XML incluye, y sobre todo <gml:name> es parte del estandar GML,
+# asi que casi toda capa lo trae exista o no la columna.
+esquema <- function(url) {
+  if (!grepl("[tT]ype[nN]ames?=", url)) return(NULL)
+  tn <- sub(".*[tT]ype[nN]ames?=([^&#]*).*", "\\1", url)
+  # Dos capas separadas por coma no tienen un esquema unico.
+  if (grepl(",", tn, fixed = TRUE)) return(NULL)
+  base <- sub("\\?.*", "", sub("^WFS:", "", url))
+  r <- consultar(paste0(base, "?service=WFS&version=1.0.0",
+                        "&request=DescribeFeatureType&typeName=", tn), FALSE)
+  if (r$curl != 0L || !identical(r$codigo, "200")) return(NULL)
+  if (grepl("ExceptionReport|ServiceException", r$texto, ignore.case = TRUE)) return(NULL)
+  campos <- regmatches(r$texto, gregexpr('name="[A-Za-z_0-9]+"', r$texto))[[1]]
+  campos <- unique(sub('name="', "", sub('"$', "", campos)))
+  if (length(campos) == 0) NULL else campos
+}
+
+# gml_id no figura en ningun esquema porque no es un campo de la capa: es el
+# identificador de la feature. Pero sf lo agrega como columna al leer, asi que
+# las nueve capas que lo declaran estan bien y no hay que avisar por ellas.
+# Comprobado en Peajes y en Lagunas publicas: las dos lo traen.
+columnas_declaradas_faltantes <- function(fila) {
+  declaradas <- c(cod = fila$cod, name = fila$name)
+  declaradas <- declaradas[!is.na(declaradas) & declaradas != "gml_id"]
+  if (length(declaradas) == 0) return(NULL)
+  campos <- esquema(fila$url)
+  if (is.null(campos)) return(NULL)   # sin esquema consultable, no se opina
+  faltan <- declaradas[!declaradas %in% campos]
+  if (length(faltan) == 0) return(NULL)
+  sprintf("%s='%s'", names(faltan), faltan)
+}
+
 filas <- vector("list", nrow(metadata))
 for (i in seq_len(nrow(metadata))) {
   capa <- metadata$capa[i]
-  url  <- endpoint(metadata$url[i], metadata$repositor[i])
+  url  <- endpoint(metadata$url[i])
   if (is.na(url)) {
     filas[[i]] <- data.frame(capa = capa, servidor = "-", motivo = "URL invalida en el metadata", ok = FALSE)
     cat(sprintf("%-5s %-32s %s\n", "FALLA", capa, "URL invalida")); next
@@ -102,34 +134,64 @@ for (i in seq_len(nrow(metadata))) {
   cab <- es_archivo(metadata$url[i], metadata$formato[i])
   r <- consultar(url, cab)
   motivo <- clasificar(r, cab)
+  # Las columnas solo se miran si la capa respondio: si el servicio esta caido,
+  # avisar ademas que no se pudo verificar la ficha es ruido sobre ruido.
+  faltan <- if (motivo == "ok") columnas_declaradas_faltantes(metadata[i, ]) else NULL
   filas[[i]] <- data.frame(capa = capa, servidor = sub("^(https?://[^/?]+).*", "\\1", r$url),
-                           motivo = motivo, ok = motivo == "ok")
-  cat(sprintf("%-5s %-32s %s\n", if (motivo == "ok") "ok" else "FALLA", capa, motivo))
+                           motivo = motivo, ok = motivo == "ok",
+                           columnas = if (is.null(faltan)) NA_character_ else paste(faltan, collapse = " "))
+  estado <- if (motivo != "ok") "FALLA" else if (!is.null(faltan)) "FICHA" else "ok"
+  cat(sprintf("%-5s %-32s %s\n", estado, capa,
+              if (motivo != "ok") motivo else if (!is.null(faltan))
+                paste("declara una columna que no existe:", paste(faltan, collapse = " ")) else ""))
 }
 res <- do.call(rbind, filas)
 caidas <- res[!res$ok, ]
+# Dos problemas distintos y con urgencias distintas: que un servicio no responda
+# no depende de nosotros y suele arreglarse solo; que la ficha declare una
+# columna que no existe es nuestro y rompe where_uy() todos los dias.
+fichas <- res[res$ok & !is.na(res$columnas), ]
 cat("\n==== ", nrow(res) - nrow(caidas), " de ", nrow(res), " capas responden ====\n", sep = "")
+if (nrow(fichas) > 0)
+  cat("==== ", nrow(fichas), " declaran una columna que no existe ====\n", sep = "")
 
 saveRDS(res, "chequeo-capas.rds")
-# Una huella de QUE esta caido, sin fecha: el workflow la usa para no repetir el
-# mismo aviso cada semana cuando no cambio nada.
-writeLines(sort(sprintf("%s\t%s", caidas$capa, caidas$motivo)), "chequeo-capas.estado")
+# Una huella de QUE esta mal, sin fecha: el workflow la usa para no repetir el
+# mismo aviso cada semana cuando no cambio nada. Incluye las dos clases, asi que
+# si una capa vuelve pero otra estrena un problema de ficha, el aviso se
+# actualiza igual.
+writeLines(sort(c(sprintf("%s\t%s", caidas$capa, caidas$motivo),
+                  sprintf("%s\tficha: %s", fichas$capa, fichas$columnas))),
+           "chequeo-capas.estado")
 
+limpiar <- function(x) gsub("[|`\r\n]", " ", x)
 con <- file("chequeo-capas.md", "w", encoding = "UTF-8")
-if (nrow(caidas) == 0) {
-  writeLines(sprintf("Las %d capas del metadata responden.", nrow(res)), con)
-} else {
-  limpiar <- function(x) gsub("[|`\r\n]", " ", x)
-  writeLines(c(
+partes <- character()
+if (nrow(caidas) > 0) {
+  partes <- c(partes,
     sprintf("**%d de %d capas no responden.**", nrow(caidas), nrow(res)), "",
     "| Capa | Servidor | Qué pasa |", "|---|---|---|",
     sprintf("| `%s` | %s | %s |", limpiar(caidas$capa), limpiar(caidas$servidor), limpiar(caidas$motivo)), "",
     "Se pide una sola feature por capa, o la cabecera si es un archivo: esto dice",
-    "si el servicio está y la capa existe, no que los datos sigan siendo los mismos."), con)
+    "si el servicio está y la capa existe, no que los datos sigan siendo los mismos.", "")
 }
+if (nrow(fichas) > 0) {
+  partes <- c(partes,
+    sprintf("**%d capas responden, pero declaran una columna que no existe.**", nrow(fichas)), "",
+    "| Capa | Columna declarada |", "|---|---|",
+    sprintf("| `%s` | %s |", limpiar(fichas$capa), limpiar(fichas$columnas)), "",
+    "Estas son nuestras y rompen `where_uy()`: el servicio responde bien, lo que",
+    "está mal es lo que el metadata dice de él. Se comparan las columnas que la",
+    "fila declara en `cod` y `name` contra el esquema que el servicio publica por",
+    "`DescribeFeatureType`.", "")
+}
+if (length(partes) == 0) {
+  partes <- sprintf("Las %d capas del metadata responden, y las columnas que declaran existen.", nrow(res))
+}
+writeLines(partes, con)
 close(con)
 
-# 2 es el hallazgo esperado, o sea que hay capas caidas. Cualquier otro codigo
-# distinto de cero significa que se rompio el chequeador, que es otra cosa y tiene
-# que dejar el workflow en rojo.
-quit(status = if (nrow(caidas) > 0) 2L else 0L)
+# 2 es el hallazgo esperado: hay algo para avisar. Cualquier otro codigo distinto
+# de cero significa que se rompio el chequeador, que es otra cosa y tiene que
+# dejar el workflow en rojo.
+quit(status = if (nrow(caidas) > 0 || nrow(fichas) > 0) 2L else 0L)

--- a/.github/workflows/chequeo-capas.yaml
+++ b/.github/workflows/chequeo-capas.yaml
@@ -57,10 +57,12 @@ jobs:
             chequeo-capas.rds
             chequeo-capas.estado
 
-      # Un issue por vez, y sólo se comenta cuando cambia QUÉ está caído. Si no,
-      # con 30 capas caídas desde hace meses llegaría un comentario idéntico todos
-      # los lunes.
-      - name: Avisar si alguna capa no responde
+      # Un issue por vez, y sólo se comenta cuando cambia QUÉ está mal. Si no, con
+      # veinte capas caídas desde hace meses llegaría un comentario idéntico todos
+      # los lunes. El título no habla de capas caídas porque el aviso puede ser
+      # sólo de fichas: que una fila declare una columna que no existe no tiene
+      # nada que ver con que el servicio responda.
+      - name: Avisar si hay algo para revisar
         if: steps.chequeo.outputs.codigo == '2'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,8 +74,8 @@ jobs:
           printf '\n<!-- huella:%s -->\n' "$huella" >> "$cuerpo"
           numero=$(gh issue list --label "capas-caidas" --state open --limit 1 --json number --jq '.[0].number // empty')
           if [ -z "$numero" ]; then
-            gh label create "capas-caidas" --color B60205 --description "Capas cuyo servicio dejó de responder" 2>/dev/null || true
-            gh issue create --title "Hay capas que no responden" --label "capas-caidas" --body-file "$cuerpo"
+            gh label create "capas-caidas" --color B60205 --description "Capas caídas o con el metadata desactualizado" 2>/dev/null || true
+            gh issue create --title "Revisión semanal de las capas" --label "capas-caidas" --body-file "$cuerpo"
           elif gh issue view "$numero" --json body --jq .body | grep -qF "huella:$huella"; then
             echo "Sigue igual que la semana pasada; no comento."
           else


### PR DESCRIPTION
Cierra el #33. Y no es una mejora teórica: corriéndolo una vez encontró seis
capas rotas, que van en el #46.

## El problema

El chequeo semanal comprobaba que el servicio respondiera, pero no que el
metadata dijera la verdad. Y con `where_uy()` ya van **diez capas** rotas porque
la fila declaraba una columna que no existe:

- tres en el #32, las del Censo 2011
- una en el #41, `Localidades pt`
- seis en el #46, que son las que encontró esto

Las cuatro primeras aparecieron de casualidad, mirando otra cosa.

## Qué hace ahora

Compara lo que cada fila declara en `cod` y `name` contra el esquema que el
servicio publica. Corrido contra los 90 servicios:

```
==== 71 de 90 capas responden ====
==== 6 declaran una columna que no existe ====

FICHA SeccHog11       cod='codsecc'
FICHA SeccPob11       cod='codsecc'
FICHA SeccPobHom11    cod='codsecc'
FICHA SeccPobMuj11    cod='codsecc'
FICHA SeccViv11       cod='codsecc'
FICHA Rutas           cod='numero' name='nombre'
```

Exactamente las seis que sabemos que están mal, **sin un solo falso positivo**.

## Por qué DescribeFeatureType

Pensé primero en pedir una feature y buscar el nombre de la columna en el
cuerpo. Es la idea obvia y está rota por construcción:

- `depto` matchea adentro de `coddepto`, y `cod` adentro de `codloc`. Justo
  `cod` es la columna más declarada, así que la más importante sería la más
  fácil de aprobar por error.
- El nombre de la capa aparece en la URL que el propio XML incluye en su
  `schemaLocation`.
- Y la peor: **`<gml:name>` es parte del estándar GML**, así que casi toda capa
  lo trae exista o no la columna `name`. Eso solo invalidaba el chequeo de
  `name` en las 27 capas que vuelven GML.

`DescribeFeatureType` no tiene nada de eso: devuelve el esquema sin datos y los
nombres vienen en atributos `name="..."`. Y es mucho más barato:

```
GetFeature&maxFeatures=1     210172 bytes
DescribeFeatureType            1743 bytes
```

Ciento veinte veces menos, porque `GetFeature` trae la geometría entera aunque
se pida un solo registro.

Comprobé además que el esquema sirva para las capas que el paquete baja como
shapefile, que era la duda razonable: coinciden con las columnas reales en las
tres que probé, salvo la de geometría y el nombre del tipo, que son
estructurales.

## La excepción que hay que tener

`gml_id` queda afuera. No figura en ningún esquema porque **no es un campo de la
capa**: es el identificador de la feature. Pero `sf` lo agrega como columna al
leer, así que las nueve capas que lo declaran están bien. Comprobado en `Peajes`
y `Lagunas publicas`, las dos lo traen.

Sin esa excepción, el chequeo avisaría todas las semanas por nueve capas sanas,
y en dos meses nadie lo lee más.

## El aviso separa las dos clases

Que un servicio no responda y que la ficha esté mal son dos urgencias distintas:
lo primero no depende de nosotros y suele arreglarse solo, lo segundo es nuestro
y rompe `where_uy()` todos los días. El issue que abre el workflow ahora tiene
una sección para cada uno.

Y las columnas sólo se miran si la capa respondió: avisar que no se pudo
verificar la ficha de un servicio caído es ruido sobre ruido.

## Aparte: un .gitattributes, para que no te vuelva a trabar un merge

Van dos cosas que te ahorran los conflictos que te tocaron:

**`NEWS.md merge=union`.** Cuando dos ramas agregan su línea en el mismo punto
no hay nada que elegir: van las dos. Con esto git las deja a las dos en vez de
marcar un conflicto. Probado con dos ramas de prueba: sin el archivo chocan, con
el archivo no.

**Los `.rda` marcados como binarios**, con la nota al lado de que ante un choque
la salida es **regenerarlos** desde `data-raw/metadata.R` -que sí se fusiona
solo, porque es texto- y no elegir una de las dos versiones. Es lo que hicimos
en el #32 y conviene que quede escrito donde alguien lo va a leer justo cuando
le pase.

De paso sale la rama del SGM del chequeo, que quedó muerta cuando esas capas
pasaron al IGM.
