### PR TITLE
Un archivo por cambio en news/, para que los PR dejen de chocar

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^chequeo-capas\.rds$
 ^chequeo-capas\.estado$
 ^\.gitattributes$
+^news$

--- a/.github/scripts/consolidar-news.R
+++ b/.github/scripts/consolidar-news.R
@@ -1,0 +1,73 @@
+# Junta los fragmentos de news/ en el NEWS.md, bajo el encabezado de la version
+# que declara el DESCRIPTION, y los borra.
+#
+# Se corre a mano al preparar una release:
+#   source(".github/scripts/consolidar-news.R")
+#
+# Es deliberadamente conservador: inserta y borra, no reescribe. El encabezado
+# de version de este NEWS.md tiene un formato propio ("## geouy v0.2.9") y no
+# conviene tocarlo desde un script.
+
+consolidar_news <- function(dir_news = "news", archivo = "NEWS.md",
+                            descripcion = "DESCRIPTION", borrar = TRUE) {
+  stopifnot(file.exists(archivo), dir.exists(dir_news))
+
+  fragmentos <- setdiff(list.files(dir_news, pattern = "\\.md$", full.names = TRUE),
+                        file.path(dir_news, "README.md"))
+  if (length(fragmentos) == 0) {
+    message("No hay fragmentos en ", dir_news, "/. No se toca el ", archivo, ".")
+    return(invisible(character()))
+  }
+
+  version <- read.dcf(descripcion, fields = "Version")[[1]]
+  news <- readLines(archivo, warn = FALSE)
+  # El encabezado de la version en curso. Se busca el que empieza con "## " y
+  # contiene la version del DESCRIPTION, sin asumir como esta escrito el resto.
+  cabecera <- grep(paste0("^##\\s.*", gsub(".", "\\.", version, fixed = TRUE)), news)
+  if (length(cabecera) != 1) {
+    stop("Esperaba un solo encabezado de la version ", version, " en ", archivo,
+         " y encontre ", length(cabecera), ". Revisalo a mano.", call. = FALSE)
+  }
+
+  # Los fragmentos van en orden del numero que llevan adelante, que con el
+  # numero de PR queda en orden de creacion. Ordenar por nombre no sirve: como
+  # texto, "100" va antes que "99".
+  numero <- suppressWarnings(as.numeric(sub("^(\\d+).*", "\\1", basename(fragmentos))))
+  fragmentos <- fragmentos[order(numero, basename(fragmentos), na.last = TRUE)]
+  entradas <- unlist(lapply(fragmentos, function(f) {
+    linea <- readLines(f, warn = FALSE)
+    # Se descartan las lineas vacias del principio y del final para que no
+    # queden huecos entre una entrada y la siguiente.
+    linea <- linea[cumsum(nzchar(linea)) > 0]
+    rev(rev(linea)[cumsum(nzchar(rev(linea))) > 0])
+  }))
+  if (length(entradas) == 0) {
+    stop("Los fragmentos estan vacios. No se toca el ", archivo, ".", call. = FALSE)
+  }
+
+  # Va una linea en blanco despues del encabezado y ninguna al final: las
+  # entradas nuevas quedan pegadas a las que ya estaban, como viñetas de la
+  # misma lista.
+  salida <- append(news, c("", entradas), after = cabecera)
+  # Si el archivo ya tenia una linea en blanco despues del encabezado, ahora
+  # habria dos seguidas.
+  sobrante <- cabecera + 1 + length(entradas) + 1
+  if (sobrante <= length(salida) && !nzchar(salida[sobrante])) salida <- salida[-sobrante]
+  writeLines(salida, archivo, useBytes = TRUE)
+
+  message(length(fragmentos), " fragmento(s) sumados a ", archivo,
+          " bajo la version ", version, ":")
+  for (f in fragmentos) message("  - ", basename(f))
+  if (borrar) {
+    unlink(fragmentos)
+    message("Fragmentos borrados. Revisa el ", archivo, " antes de commitear.")
+  } else {
+    message("Fragmentos conservados (borrar = FALSE).")
+  }
+  invisible(fragmentos)
+}
+
+# Se corre al sourcear: es lo unico para lo que existe este archivo. Si se
+# quiere sólo la función, sin ejecutarla:
+#   source(".github/scripts/consolidar-news.R", local = new.env())
+consolidar_news()

--- a/news/53-fragmentos.md
+++ b/news/53-fragmentos.md
@@ -1,0 +1,3 @@
+* The `NEWS.md` entries of a change now live in their own file under `news/`
+  until a release consolidates them, so two pull requests no longer collide on
+  the same lines of the same file.

--- a/news/README.md
+++ b/news/README.md
@@ -1,0 +1,52 @@
+# Fragmentos del NEWS
+
+Cada cambio que merezca una línea en el `NEWS.md` va acá, en **su propio
+archivo**. Al preparar una release se consolidan todos en el `NEWS.md` y se
+borran.
+
+## Por qué
+
+Cuando varios PR agregan su entrada directamente al `NEWS.md`, chocan entre
+ellos: todos escriben en el mismo lugar del mismo archivo. Con un archivo por
+cambio eso no puede pasar, porque nadie más lo toca.
+
+Se probó antes la vía automática -`NEWS.md merge=union` en el `.gitattributes`-
+y resuelve el conflicto **sólo cuando se fusiona desde la línea de comandos**:
+GitHub no aplica los merge drivers, así que al mergear desde la web el conflicto
+aparece igual.
+
+## Cómo se usa
+
+Creá un archivo con el número del PR y unas palabras que digan de qué se trata:
+
+```
+news/52-tidyselect-add-geom.md
+```
+
+Adentro va la entrada tal como quedaría en el `NEWS.md`, con su viñeta:
+
+```markdown
+* `add_geom()` no longer uses an external vector inside a selection, which
+  `tidyselect` deprecated in 1.1.0.
+```
+
+Un par de convenciones que conviene mantener:
+
+- **En inglés**, como el resto del `NEWS.md`.
+- **Qué cambió para quien usa el paquete**, no cómo está implementado.
+- Si el PR arregla algo, decir qué pasaba antes: es lo que sirve leer después.
+- Podés poner más de una viñeta si el PR trae varias cosas.
+
+El número del PR no se conoce hasta abrirlo, así que lo normal es crear el
+archivo en el segundo commit, después de que GitHub asigne el número. Si te
+resulta más cómodo, empezá con el nombre de la rama y renombralo después.
+
+## Al preparar una release
+
+```r
+source(".github/scripts/consolidar-news.R")
+```
+
+Junta los fragmentos bajo el encabezado de la versión actual del `DESCRIPTION`,
+los borra, y dice qué hizo. Después se revisa el `NEWS.md` a mano: el script
+ordena y pega, no escribe.


### PR DESCRIPTION
Cierra el #49, con tu propuesta de los fragmentos.

## Por qué la automática no alcanzaba

Te había dicho que el `.gitattributes` con `merge=union` lo resolvía. Lo probé
cuando me contaste que te trancaba el segundo PR, y **no**:

```
merge local en mi máquina:   0 conflictos
lo que dice GitHub:          CONFLICTING
```

Mismo commit, misma rama. **GitHub no aplica los merge drivers del
`.gitattributes`.** La regla anda desde la línea de comandos, pero el botón de
mergear de la web la ignora, y como vos mergeás desde ahí, para vos es como si
no existiera.

Así que va tu idea, que resuelve el problema por construcción en vez de depender
de que la herramienta coopere.

## Cómo queda

Cada cambio que merezca una línea en el `NEWS.md` va en **su propio archivo**:

```
news/
  README.md              <- cómo se usa
  52-tidyselect.md
  53-fragmentos.md
```

Nadie más toca ese archivo, así que no puede chocar. Al preparar la release:

```r
source(".github/scripts/consolidar-news.R")
```

Junta los fragmentos bajo el encabezado de la versión que declara el
`DESCRIPTION`, los borra y dice qué hizo.

El script es **deliberadamente conservador**: inserta y borra, no reescribe. El
encabezado de versión de este `NEWS.md` tiene un formato propio -`## geouy
v0.2.9`- y no me parece que un script deba andar tocándolo.

Un detalle que costó ver: ordena por el número que el fragmento lleva adelante y
no por nombre de archivo, porque como texto **"100" va antes que "99"**.

## Probado

```
carpeta vacía             no toca el NEWS.md
fragmento vacío           corta sin tocarlo
nombre sin número         funciona igual
el README                 no se consume
dos corridas seguidas     no duplica nada
```

Y lo que más me importaba comprobar: el `NEWS.md` **se sigue parseando igual**
antes y después, con sus diecinueve encabezados de versión intactos. Un script
que toca ese archivo podría romper lo que R lee con `news()`.

El `news/` queda excluido del build, así que no viaja en el paquete.

## Una objeción que te paso, porque es justa

Esto cambia el conflicto por otro riesgo: **que alguien se olvide de crear el
fragmento**. El PR se mergea sin problema y el cambio queda sin documentar, que
es peor que un conflicto porque no avisa.

Me pareció que igual conviene, porque un conflicto te bloquea el merge y te
obliga a pedirme que lo destrabe -pasó tres veces esta semana- mientras que el
olvido se ve al preparar la release, comparando contra los PR mergeados. Pero si
te parece, se puede agregar un chequeo en el CI que pida un fragmento por PR.
Yo no lo pondría todavía: para dos personas me parece más burocracia que
beneficio.

El `.gitattributes` lo dejo como está: no molesta, y a quien fusione desde la
terminal le sigue sirviendo.
