### PR TITLE
Que una regeneración no se confunda con una capa caída

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^chequeo-capas\.rds$
 ^chequeo-capas\.estado$
 ^\.gitattributes$
+^news$

--- a/.github/scripts/chequeo-capas.R
+++ b/.github/scripts/chequeo-capas.R
@@ -44,7 +44,12 @@ endpoint <- function(url) {
   url
 }
 
-consultar <- function(url, solo_cabecera) {
+# tope: cuantos bytes del cuerpo se leen. 64 KB alcanzan de sobra para
+# reconocer un GML, un JSON o un zip por su primer bloque, y evitan cargar una
+# capa entera en memoria. El indice de un directorio es otra cosa: el de MIDES
+# pesa 118 KB y el archivo que se busca puede estar en cualquier parte, asi que
+# ahi se pide mas.
+consultar <- function(url, solo_cabecera, tope = 65536L) {
   cuerpo <- tempfile()
   on.exit(unlink(cuerpo), add = TRUE)
   args <- c("-sS", "-o", shQuote(cuerpo),
@@ -60,10 +65,39 @@ consultar <- function(url, solo_cabecera) {
     return(list(codigo = "000", bytes = 0, url = url, curl = estado, texto = ""))
   }
   p <- strsplit(sub("^GEOUY:", "", linea[length(linea)]), ":", fixed = TRUE)[[1]]
-  n <- suppressWarnings(min(file.info(cuerpo)$size, 65536L))
+  n <- suppressWarnings(min(file.info(cuerpo)$size, tope))
   texto <- if (!is.na(n) && n > 0) readChar(cuerpo, n, useBytes = TRUE) else ""
   list(codigo = p[1], bytes = as.numeric(p[2]),
        url = paste(p[-(1:2)], collapse = ":"), curl = 0L, texto = texto)
+}
+
+# Los archivos estaticos de algunos servidores se regeneran: se borran y se
+# vuelven a crear, y mientras tanto devuelven 404 aunque el servicio este
+# perfecto. Nos paso con "Educacion especial", que estuvo casi veinte horas asi
+# y volvio sola: el chequeo la reporto caida y no lo estaba.
+#
+# Antes de darla por caida se mira el indice del directorio. Si el archivo sigue
+# listado ahi, lo mas probable es que se este regenerando y no que lo hayan dado
+# de baja. De los tres servidores que sirven archivos estaticos solo uno publica
+# indice, asi que cuando no hay se reporta como antes.
+#
+# Ojo: uno de esos servidores contesta HTTP 200 con una pagina de error en vez
+# de 404, asi que mirar el codigo no alcanza. Se exige que el cuerpo tenga
+# varias entradas de archivo, que es lo que distingue un listado de una pagina
+# cualquiera servida con 200.
+figura_en_el_indice <- function(url) {
+  archivo <- basename(sub("[?#].*", "", url))
+  if (!nzchar(archivo)) return(FALSE)
+  indice <- sub("[^/]*$", "", sub("[?#].*", "", url))
+  # El indice se lee entero: el archivo buscado puede estar al final. Se pone un
+  # techo igual, para que un servidor que devuelva algo enorme no llene la
+  # memoria del runner.
+  r <- consultar(indice, FALSE, tope = 4194304L)
+  if (r$curl != 0L || !identical(r$codigo, "200")) return(FALSE)
+  listados <- regmatches(r$texto, gregexpr('href="[^"?/][^"]*"', r$texto))[[1]]
+  listados <- sub('href="', "", sub('"$', "", listados))
+  if (length(listados) < 2) return(FALSE)
+  archivo %in% listados
 }
 
 # Un 200 no alcanza: los geoserver contestan las excepciones con codigo 200 y un
@@ -134,6 +168,10 @@ for (i in seq_len(nrow(metadata))) {
   cab <- es_archivo(metadata$url[i], metadata$formato[i])
   r <- consultar(url, cab)
   motivo <- clasificar(r, cab)
+  # Un 404 en un archivo estatico puede ser una regeneracion en curso.
+  if (cab && identical(r$codigo, "404") && figura_en_el_indice(url)) {
+    motivo <- "no se puede bajar ahora, pero sigue listado en el directorio"
+  }
   # Las columnas solo se miran si la capa respondio: si el servicio esta caido,
   # avisar ademas que no se pudo verificar la ficha es ruido sobre ruido.
   faltan <- if (motivo == "ok") columnas_declaradas_faltantes(metadata[i, ]) else NULL

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,6 @@
 
 ## geouy v0.2.9
 
-* The weekly layer check no longer reports a static file as down on a single
-  404. Those files are regenerated periodically, and while they are being
-  recreated they answer 404 even though the service is fine. The check now
-  looks at the directory index first: if the file is still listed there, it is
-  most likely being regenerated rather than withdrawn.
-
 * Fix `tiles_geouy()` returning the whole union of the tiles when the area
   spans more than one. The crop to the requested area, and the CRS, were only
   applied on the single-tile path; asking for 300 m around a point came back as

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 ## geouy v0.2.9
 
+* The weekly layer check no longer reports a static file as down on a single
+  404. Those files are regenerated periodically, and while they are being
+  recreated they answer 404 even though the service is fine. The check now
+  looks at the directory index first: if the file is still listed there, it is
+  most likely being regenerated rather than withdrawn.
+
 * Fix `tiles_geouy()` returning the whole union of the tiles when the area
   spans more than one. The crop to the requested area, and the CRS, were only
   applied on the single-tile path; asking for 300 m around a point came back as

--- a/news/54-chequeo-reintento.md
+++ b/news/54-chequeo-reintento.md
@@ -1,0 +1,5 @@
+* The weekly layer check no longer reports a static file as down on a single
+  404. Those files are regenerated periodically, and while they are being
+  recreated they answer 404 even though the service is fine. The check now
+  looks at the directory index first: if the file is still listed there, it is
+  most likely being regenerated rather than withdrawn.


### PR DESCRIPTION
Cierra la primera parte del #50: que el chequeo no confunda una regeneración con
una capa caída. La segunda parte -mirar lo que el organismo publica de nuevo- la
dejo para después, que es más trabajo y no urge.

## El problema

Con `Educacion especial` pasó esto:

```
07/09 15:12   el chequeo la reporta caída con 404
08/09 ~03:00  sigue faltando, seis intentos de seis
08/09 10:42   el zip aparece en el directorio con esa fecha
09/09         responde 200, estable
```

Casi veinte horas ausente, y volvió sola. Y no es un caso raro: de los 79 zip
de ese directorio, **8 se generaron hoy, 2 ayer y 12 hace cuatro días**. Con esa
frecuencia el chequeo va a caer en una ventana cada tanto, y una falsa alarma
por semana alcanza para que en dos meses nadie lo lea.

## Qué hace ahora

Antes de dar por caído un archivo estático, mira el índice del directorio. Si
sigue listado, lo reporta distinto:

```
no se puede bajar ahora, pero sigue listado en el directorio
```

De los tres servidores que sirven archivos estáticos **sólo uno publica
índice**, así que cuando no hay se reporta como antes.

Un detalle que hay que tener en cuenta: uno de esos servidores contesta **HTTP
200 con una página de error** en vez de 404, así que mirar el código no alcanza.
Se exige que el cuerpo tenga varias entradas de archivo, que es lo que distingue
un listado de una página cualquiera.

## El bug que casi se me pasa

Los cinco casos de prueba dieron cuatro bien y **falló justo el positivo**:
`liceos.zip` figura en el índice y la función decía que no.

La causa: el índice pesa **118 KB**, `liceos.zip` está en el byte **81930**, y
el chequeo leía sólo 64 KB del cuerpo. Más de la mitad de las entradas eran
invisibles.

Lo peligroso es que sin ese control positivo el cambio pasaba: los cuatro casos
negativos daban bien y nada se rompía. En producción la función habría devuelto
siempre `FALSE`, o sea comportándose igual que antes pero con apariencia de
estar arreglada.

Ahora `consultar()` acepta cuánto leer: 64 KB por omisión, que alcanza de sobra
para reconocer un GML o un zip por su primer bloque, y más para el índice.

## Probado

La función sola, contra los servidores reales:

```
MIDES, archivo que existe        -> TRUE
MIDES, archivo inventado         -> FALSE
MVOT (200 con página de error)   -> FALSE
Ambiente (sin índice)            -> FALSE
url sin nombre de archivo        -> FALSE
```

Y de punta a punta, forzando el escenario -porque hoy no hay ninguna capa
regenerándose y la rama nueva no se ejecutaría sola-:

```
archivo que SÍ figura, con 404   -> "no se puede bajar ahora, pero sigue listado"
archivo que NO figura, con 404   -> "HTTP 404"
servidor sin índice, con 404     -> "HTTP 404"
el camino feliz                  -> "ok"
```

Corrido completo contra los 90 servicios: **71 responden, 0 fichas mal**. Las
seis fichas que había desaparecieron porque mergeaste el #46, y las 19 caídas
son todas de Ambiente por lo del certificado (#30).
