### PR TITLE
citation("geouy") imprimía el año como ???? y descartaba el textVersion

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^chequeo-capas\.rds$
 ^chequeo-capas\.estado$
 ^\.gitattributes$
+^news$

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,16 +1,24 @@
 citHeader("To cite geouy in publications use:")
 
-year <- sub("-.*", "", meta$Date)
+# El DESCRIPTION no trae campo Date, asi que meta$Date es NULL y el ano salia
+# vacio: la cita imprimia "(????)". Lo que si traen los paquetes instalados
+# desde CRAN es Date/Publication, que lo agrega CRAN al publicar. Si no esta
+# ninguno de los dos (instalado desde el repo), queda el ano en curso.
+year <- meta$`Date/Publication`
+if (is.null(year)) year <- meta$Date
+year <- if (is.null(year)) format(Sys.Date(), "%Y") else sub("-.*", "", year)
+
 note <- sprintf("R package version %s", meta$Version)
+url <- "https://github.com/RichDeto/geouy"
 
 bibentry(bibtype = "Misc",
          title = "{geouy}: Geographic Information of Uruguay",
          author = c(person("Richard", "Detomasi")),
          year = year,
          note = note,
-	       url = "https://github.com/RichDeto/geouy")
-
-textVersion = paste0("Detomasi, Richard, (", year, ").",
-  "geouy: Geographic Information of Uruguay. ",
-  note, ".",
-  " https://github.com/RichDeto/geouy")
+         url = url,
+         # Iba con "=" fuera de la llamada, asi que era una variable suelta y
+         # bibentry nunca la recibia.
+         textVersion = paste0("Detomasi, Richard, (", year, "). ",
+                              "geouy: Geographic Information of Uruguay. ",
+                              note, ". ", url))

--- a/news/56-citation.md
+++ b/news/56-citation.md
@@ -1,0 +1,7 @@
+* `citation("geouy")` printed the year as `????`. It was taken from the `Date`
+  field of the DESCRIPTION, which this package does not have; it now comes from
+  `Date/Publication`, the field CRAN adds when it publishes, and falls back to
+  the current year when neither is there.
+* The `textVersion` of the citation was written outside the call to
+  `bibentry()`, so it was an unused variable and what `citation()` showed was
+  the text `bibentry` builds on its own.


### PR DESCRIPTION
Dos bugs en el `inst/CITATION`, los dos de larga data.

**El año salía `????`.** El archivo lo saca de `sub("-.*", "", meta$Date)`, pero
el DESCRIPTION no tiene campo `Date`. Entonces `meta$Date` es `NULL`, `year`
queda en `character(0)` y `bibentry` lo imprime como `????`. Instalé el paquete
y corrí `citation("geouy")` para verlo:

```
  Detomasi R (????). “geouy: Geographic Information of Uruguay.”
  R package version 0.2.9, <https://github.com/RichDeto/geouy>.
```

Lo que sí traen los paquetes instalados desde CRAN es `Date/Publication`, que lo
agrega CRAN al publicar. Va ese primero, después `Date` por si algún día se
agrega al DESCRIPTION, y si no está ninguno de los dos —instalado desde el
repo— el año en curso. Con el cambio, la misma instalación:

```
  Detomasi, Richard, (2026). geouy: Geographic Information of Uruguay.
  R package version 0.2.9. https://github.com/RichDeto/geouy
```

**El `textVersion` no llegaba.** Estaba escrito con `=` afuera de la llamada a
`bibentry()`, así que no era un argumento sino una variable suelta que nadie
leía. La cita en texto que se veía era la que arma `bibentry` sola, no la del
archivo. Se nota en el bloque de arriba: la segunda es la del archivo.

La URL la dejé como está a propósito: apunta al repo viejo, igual que el
`BugReports` del DESCRIPTION y las instrucciones de instalación del README, y
eso es una decisión tuya. Te lo dejo en un issue aparte.

El `^news$` del `.Rbuildignore` es la misma línea que traen los otros PR.
