### PR TITLE
Avisar de las capas que los organismos publican y el paquete no tiene

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,5 +25,8 @@
 ^chequeo-capas\.md$
 ^chequeo-capas\.rds$
 ^chequeo-capas\.estado$
+^catalogo-capas\.md$
+^catalogo-capas\.rds$
+^catalogo-capas\.estado$
 ^\.gitattributes$
 ^news$

--- a/.github/scripts/catalogo-capas.R
+++ b/.github/scripts/catalogo-capas.R
@@ -1,0 +1,241 @@
+# Mira que publican los organismos y avisa de lo que aparecio desde la corrida
+# anterior. Es la contracara del chequeo semanal: aquel detecta que lo nuestro
+# se rompa, este detecta que ellos sacaron algo nuevo.
+#
+# Va aparte de chequeo-capas.R a proposito. Son preguntas distintas, con
+# salidas distintas, y sobre todo: si el catalogo falla, el chequeo de capas
+# caidas tiene que seguir funcionando igual.
+#
+# Deliberadamente NO reporta "capas que ellos tienen y nosotros no". Eso da 72
+# faltantes todas las semanas y muere a la primera. Reporta el diff contra la
+# foto de la corrida anterior: lo que no estaba y ahora esta.
+#
+# Codigos de salida: 0 sin novedades, 2 hay algo nuevo, cualquier otro es que se
+# rompio el script.
+
+.comun <- function() {
+  a <- commandArgs(trailingOnly = FALSE)
+  f <- sub("^--file=", "", a[grep("^--file=", a)])
+  candidatos <- c(if (length(f)) file.path(dirname(normalizePath(f[1])), "comun.R"),
+                  file.path(".github", "scripts", "comun.R"), "comun.R")
+  hay <- candidatos[file.exists(candidatos)]
+  if (!length(hay)) stop("No encuentro comun.R; se lo busco en: ",
+                         paste(candidatos, collapse = ", "))
+  hay[1]
+}
+source(.comun())
+
+load("data/metadata.rda")
+
+es_wfs <- function(url) grepl("request=GetFeature", url, ignore.case = TRUE)
+# Con "&" y no "&&": aca se llama sobre la columna entera, no fila por fila.
+es_archivo <- function(url, formato) formato %in% c("zip", "zip a") & !es_wfs(url)
+
+# Vectorizada: se la llama tanto sobre una URL suelta como sobre la columna.
+tipo_de_capa <- function(url) {
+  tn <- rep(NA_character_, length(url))
+  hay <- grepl("[tT]ype[nN]ames?=", url)
+  if (any(hay)) {
+    tn[hay] <- vapply(sub(".*[tT]ype[nN]ames?=([^&#]*).*", "\\1", url[hay]),
+                      utils::URLdecode, "", USE.NAMES = FALSE)
+  }
+  tn
+}
+
+# De que catalogo sale una capa WFS. La idea es mirar el workspace y no el
+# servidor entero: el geoserver-vectorial del IDE publica 552 capas -catastro,
+# cartografia nacional, todo- y el del MTOP 267. Una capa nueva ahi no tiene
+# nada que ver con lo que hace el paquete y seria ruido todas las semanas. Los
+# workspaces que usamos suman 207, y una capa nueva en INECenso si es del mismo
+# tema que las que ya traemos.
+#
+# El workspace viene de dos lados segun el servidor:
+#  - MIDES lo pone en el typeName ("INECenso:Secciones") y el servicio es global.
+#  - IDE y MTOP lo ponen en la ruta. El del MTOP llega hasta la capa
+#    (/geoserver/<workspace>/<capa>/ows), asi que hay que subir un escalon.
+# ArcGIS (IGM) no tiene workspaces: cada servicio es su propio catalogo.
+catalogo_de <- function(url) {
+  base <- sub("\\?.*$", "", sub("^WFS:", "", url))
+  # El metadata escribe el mismo servidor de dos formas -con :443 y sin- y son
+  # el mismo catalogo. Sin normalizarlo se consultaba dos veces y la foto
+  # guardaba 250 entradas repetidas.
+  base <- sub("^(https)://([^/]+):443/", "\\1://\\2/", base)
+  base <- sub("^(http)://([^/]+):80/", "\\1://\\2/", base)
+  tn <- tipo_de_capa(url)
+  prefijo <- if (!is.na(tn) && grepl(":", tn, fixed = TRUE)) sub(":.*$", "", tn) else NA_character_
+
+  if (grepl("/arcgis/", base, ignore.case = TRUE)) {
+    return(list(servicio = base, workspace = NA_character_, id = base, en_la_ruta = FALSE))
+  }
+
+  # El id se arma con servidor + workspace y NO con la URL, porque el mismo
+  # catalogo se escribe de dos formas: unas filas piden /geoserver/IDE/ows y
+  # otras /geoserver/ows con typeName "IDE:algo". Son las mismas 119 capas.
+  servidor <- sub("^(https?://[^/]+)/.*$", "\\1", base)
+
+  # Lo que hay entre /geoserver.../ y el /ows o /wfs final.
+  m <- regmatches(base, regexec("^(.*/geoserver[^/]*)/(.*)/(ows|wfs)$", base, ignore.case = TRUE))[[1]]
+  if (length(m) == 4) {
+    ws <- strsplit(m[3], "/", fixed = TRUE)[[1]][1]
+    return(list(servicio = paste0(m[2], "/", ws, "/", m[4]), workspace = ws,
+                id = paste0(servidor, "|", ws), en_la_ruta = TRUE))
+  }
+
+  # Servicio global: el workspace sale del prefijo del typeName, si lo hay.
+  list(servicio = base, workspace = prefijo, en_la_ruta = FALSE,
+       id = if (is.na(prefijo)) base else paste0(servidor, "|", prefijo))
+}
+
+# Las capas que declara un GetCapabilities. Se pide 1.1.0 y no 2.0.0 a
+# proposito: con 2.0.0 el geoserver del MIDES contesta una excepcion para todo
+# el workspace porque una capa suelta -aulas_comunitarias- tiene el esquema
+# roto, y se lleva puesta la consulta entera.
+capas_publicadas <- function(servicio) {
+  sep <- if (grepl("?", servicio, fixed = TRUE)) "&" else "?"
+  r <- consultar(paste0(servicio, sep, "service=WFS&version=1.1.0&request=GetCapabilities"),
+                 FALSE, tope = 8388608L)
+  if (r$curl != 0L || !identical(r$codigo, "200")) return(NULL)
+  if (grepl("ExceptionReport|ServiceException", r$texto, ignore.case = TRUE)) return(NULL)
+  # El ArcGIS del IGM escribe <wfs:Name>; los geoserver, <Name> pelado.
+  n <- regmatches(r$texto, gregexpr("<(?:[A-Za-z0-9_]+:)?Name>[^<]+</(?:[A-Za-z0-9_]+:)?Name>",
+                                    r$texto, perl = TRUE))[[1]]
+  if (!length(n)) return(NULL)
+  n <- unique(sub("</[^>]*>$", "", sub("^<[^>]*>", "", n)))
+  # El <Name> del servicio -"WFS"- y los de los operadores no son capas.
+  n[nzchar(n) & !n %in% c("WFS", "wfs")]
+}
+
+# ---- Los catalogos que hay que mirar, sacados del metadata ------------------
+
+wfs <- metadata[es_wfs(metadata$url), , drop = FALSE]
+fuentes <- list()
+for (u in unique(wfs$url)) {
+  c1 <- catalogo_de(u)
+  # Ante dos formas del mismo catalogo gana la que trae el workspace en la ruta:
+  # el GetCapabilities acotado pesa 7 KB donde el global pesa 148.
+  if (is.null(fuentes[[c1$id]]) || (c1$en_la_ruta && !fuentes[[c1$id]]$en_la_ruta)) {
+    fuentes[[c1$id]] <- c1
+  }
+}
+
+indices <- unique(directorio_de(metadata$url[es_archivo(metadata$url, metadata$formato)]))
+
+# ---- La foto de hoy ---------------------------------------------------------
+
+# Si una fuente no contesta se ARRASTRA lo que tenia en la foto anterior. Sin
+# esto, un servidor caido dejaria la fuente vacia hoy y la semana que viene
+# reportaria todo su catalogo como novedad.
+anterior <- if (file.exists("catalogo-capas.rds")) readRDS("catalogo-capas.rds") else NULL
+
+# Una fuente que hoy viene vacia pero antes tenia cosas es casi seguro un
+# hipo del servidor, no que hayan borrado el catalogo entero. Si se guardara
+# vacia, la semana que viene todo su contenido volveria como novedad. Si de
+# verdad borraron todo, el chequeo de capas caidas lo grita igual.
+guardar <- function(id, capas) {
+  previas <- anterior[[id]]
+  if (!length(capas) && length(previas)) previas else capas
+}
+
+foto <- list()
+fallaron <- character()
+
+for (f in fuentes) {
+  capas <- capas_publicadas(f$servicio)
+  if (!is.null(capas) && !is.na(f$workspace)) {
+    # Un servicio global devuelve todo; nos quedamos con el workspace nuestro.
+    propias <- grep(paste0("^", f$workspace, ":"), capas, value = TRUE)
+    if (length(propias)) capas <- propias
+  }
+  if (is.null(capas)) {
+    fallaron <- c(fallaron, f$id)
+    if (!is.null(anterior[[f$id]])) foto[[f$id]] <- anterior[[f$id]]
+  } else {
+    foto[[f$id]] <- sort(guardar(f$id, capas))
+  }
+}
+
+# De un indice de directorio solo interesan los archivos que el paquete podria
+# llegar a bajar. El de MIDES lista 493 entradas y 83 son zip: seguir las otras
+# 410 -xml y txt de acompanamiento- seria ruido garantizado.
+sin_indice <- character()
+for (i in indices) {
+  r <- listado_del_indice(i)
+  if (identical(r$estado, "sin indice")) {
+    # No es una falla: ese directorio no publica listado y no lo va a publicar.
+    sin_indice <- c(sin_indice, i)
+    next
+  }
+  if (identical(r$estado, "sin respuesta")) {
+    fallaron <- c(fallaron, i)
+    if (!is.null(anterior[[i]])) foto[[i]] <- anterior[[i]]
+    next
+  }
+  foto[[i]] <- sort(guardar(i, grep("\\.(zip|rar|7z)$", r$archivos, value = TRUE, ignore.case = TRUE)))
+}
+
+saveRDS(foto, "catalogo-capas.rds")
+
+# ---- El diff ----------------------------------------------------------------
+
+usadas <- c(na.omit(tipo_de_capa(metadata$url)),
+            basename(sub("[?#].*", "", metadata$url[es_archivo(metadata$url, metadata$formato)])))
+sin_prefijo <- function(x) sub("^[^:]*:", "", x)
+ya_la_tenemos <- function(x) sin_prefijo(x) %in% sin_prefijo(usadas)
+
+novedades <- list()
+if (!is.null(anterior)) {
+  for (id in names(foto)) {
+    if (is.null(anterior[[id]])) next   # fuente nueva: no es novedad del organismo
+    nuevas <- setdiff(foto[[id]], anterior[[id]])
+    if (length(nuevas)) novedades[[id]] <- nuevas
+  }
+}
+
+con <- file("catalogo-capas.md", "w", encoding = "UTF-8")
+w <- function(...) cat(..., "\n", sep = "", file = con)
+
+if (is.null(anterior)) {
+  w("Primera corrida del catálogo: se guardó la foto y no hay con qué comparar.")
+  w("")
+  w("Quedaron registradas ", length(unlist(foto)), " entradas en ", length(foto), " catálogos.")
+} else if (!length(novedades)) {
+  w("Sin novedades: los organismos no publicaron nada nuevo desde la corrida anterior.")
+} else {
+  w("Apareció esto desde la corrida anterior:")
+  w("")
+  for (id in names(novedades)) {
+    w("**", id, "**")
+    w("")
+    for (x in novedades[[id]]) {
+      w("- `", x, "`", if (ya_la_tenemos(x)) " — el paquete ya la usa" else "")
+    }
+    w("")
+  }
+  w("Esto es sólo lo que **apareció**: lo que el organismo publica y el paquete")
+  w("no usa, si ya estaba en la foto anterior, no se repite.")
+}
+
+if (length(fallaron)) {
+  w("")
+  w("No contestaron, así que se arrastró lo que tenían la corrida anterior:")
+  w("")
+  for (x in fallaron) w("- `", x, "`")
+}
+
+if (length(sin_indice)) {
+  w("")
+  w("Estos directorios no publican listado, así que de ahí no se puede saber qué")
+  w("hay. No es una caída: es cómo está configurado el servidor.")
+  w("")
+  for (x in sin_indice) w("- `", x, "`")
+}
+close(con)
+
+# La huella de lo nuevo, para que el workflow no repita el mismo aviso cada
+# semana. Vacia cuando no hay novedades.
+estado <- unlist(lapply(names(novedades), function(id) paste0(id, "|", novedades[[id]])))
+writeLines(sort(as.character(estado)), "catalogo-capas.estado")
+
+cat(readLines("catalogo-capas.md"), sep = "\n")
+cat("\n")
+quit(status = if (length(novedades)) 2L else 0L)

--- a/.github/scripts/catalogo-capas.R
+++ b/.github/scripts/catalogo-capas.R
@@ -34,9 +34,9 @@ es_archivo <- function(url, formato) formato %in% c("zip", "zip a") & !es_wfs(ur
 # Vectorizada: se la llama tanto sobre una URL suelta como sobre la columna.
 tipo_de_capa <- function(url) {
   tn <- rep(NA_character_, length(url))
-  hay <- grepl("[tT]ype[nN]ames?=", url)
+  hay <- !is.na(url) & grepl("typenames?=", url, ignore.case = TRUE)
   if (any(hay)) {
-    tn[hay] <- vapply(sub(".*[tT]ype[nN]ames?=([^&#]*).*", "\\1", url[hay]),
+    tn[hay] <- vapply(sub(".*[?&]typenames?=([^&#]*).*", "\\1", url[hay], ignore.case = TRUE),
                       utils::URLdecode, "", USE.NAMES = FALSE)
   }
   tn
@@ -68,22 +68,25 @@ catalogo_de <- function(url) {
     return(list(servicio = base, workspace = NA_character_, id = base, en_la_ruta = FALSE))
   }
 
-  # El id se arma con servidor + workspace y NO con la URL, porque el mismo
-  # catalogo se escribe de dos formas: unas filas piden /geoserver/IDE/ows y
-  # otras /geoserver/ows con typeName "IDE:algo". Son las mismas 119 capas.
-  servidor <- sub("^(https?://[^/]+)/.*$", "\\1", base)
+  # El id se arma con la raiz del geoserver + el workspace, y NO con la URL
+  # entera, porque el mismo catalogo se escribe de dos formas: unas filas piden
+  # /geoserver/IDE/ows y otras /geoserver/ows con typeName "IDE:algo". Son las
+  # mismas 119 capas. La raiz va incluida y no solo el servidor: un mismo host
+  # puede tener /geoserver-vectorial y /geoserver-raster, y un workspace que se
+  # llame igual en los dos no es el mismo catalogo.
 
   # Lo que hay entre /geoserver.../ y el /ows o /wfs final.
   m <- regmatches(base, regexec("^(.*/geoserver[^/]*)/(.*)/(ows|wfs)$", base, ignore.case = TRUE))[[1]]
   if (length(m) == 4) {
     ws <- strsplit(m[3], "/", fixed = TRUE)[[1]][1]
     return(list(servicio = paste0(m[2], "/", ws, "/", m[4]), workspace = ws,
-                id = paste0(servidor, "|", ws), en_la_ruta = TRUE))
+                id = paste0(m[2], "|", ws), en_la_ruta = TRUE))
   }
 
   # Servicio global: el workspace sale del prefijo del typeName, si lo hay.
+  raiz <- sub("/(ows|wfs)$", "", base, ignore.case = TRUE)
   list(servicio = base, workspace = prefijo, en_la_ruta = FALSE,
-       id = if (is.na(prefijo)) base else paste0(servidor, "|", prefijo))
+       id = if (is.na(prefijo)) base else paste0(raiz, "|", prefijo))
 }
 
 # Las capas que declara un GetCapabilities. Se pide 1.1.0 y no 2.0.0 a
@@ -107,7 +110,7 @@ capas_publicadas <- function(servicio) {
 
 # ---- Los catalogos que hay que mirar, sacados del metadata ------------------
 
-wfs <- metadata[es_wfs(metadata$url), , drop = FALSE]
+wfs <- metadata[!is.na(metadata$url) & es_wfs(metadata$url), , drop = FALSE]
 fuentes <- list()
 for (u in unique(wfs$url)) {
   c1 <- catalogo_de(u)
@@ -118,46 +121,43 @@ for (u in unique(wfs$url)) {
   }
 }
 
-indices <- unique(directorio_de(metadata$url[es_archivo(metadata$url, metadata$formato)]))
+indices <- unique(directorio_de(metadata$url[!is.na(metadata$url) &
+                                             es_archivo(metadata$url, metadata$formato)]))
 
-# ---- La foto de hoy ---------------------------------------------------------
+# ---- Lo que se lee hoy ------------------------------------------------------
 
-# Si una fuente no contesta se ARRASTRA lo que tenia en la foto anterior. Sin
-# esto, un servidor caido dejaria la fuente vacia hoy y la semana que viene
-# reportaria todo su catalogo como novedad.
-anterior <- if (file.exists("catalogo-capas.rds")) readRDS("catalogo-capas.rds") else NULL
-
-# Una fuente que hoy viene vacia pero antes tenia cosas es casi seguro un
-# hipo del servidor, no que hayan borrado el catalogo entero. Si se guardara
-# vacia, la semana que viene todo su contenido volveria como novedad. Si de
-# verdad borraron todo, el chequeo de capas caidas lo grita igual.
-guardar <- function(id, capas) {
-  previas <- anterior[[id]]
-  if (!length(capas) && length(previas)) previas else capas
+anterior <- NULL
+if (file.exists("catalogo-capas.rds")) {
+  # Una foto ilegible no es lo mismo que no tener foto, pero tratarla igual es
+  # preferible a que el script muera: se rearma y se pierde una corrida.
+  anterior <- tryCatch(readRDS("catalogo-capas.rds"), error = function(e) {
+    message("La foto anterior no se pudo leer: ", conditionMessage(e))
+    NULL
+  })
 }
 
-foto <- list()
+visto <- list()
 fallaron <- character()
+sin_indice <- character()
 
 for (f in fuentes) {
   capas <- capas_publicadas(f$servicio)
   if (!is.null(capas) && !is.na(f$workspace)) {
-    # Un servicio global devuelve todo; nos quedamos con el workspace nuestro.
-    propias <- grep(paste0("^", f$workspace, ":"), capas, value = TRUE)
-    if (length(propias)) capas <- propias
+    # startsWith y no grep: un workspace con un punto o un corchete en el
+    # nombre seria una expresion regular y no un prefijo literal.
+    propias <- capas[startsWith(capas, paste0(f$workspace, ":"))]
+    # Los servicios acotados al workspace tambien devuelven los nombres con
+    # prefijo, asi que si el filtro no deja nada es que lo que vino no es el
+    # catalogo que esperabamos. Vale mas darlo por lectura fallida que guardar
+    # las 135 capas del servidor entero bajo el id de un workspace.
+    capas <- if (length(propias)) propias else NULL
   }
-  if (is.null(capas)) {
-    fallaron <- c(fallaron, f$id)
-    if (!is.null(anterior[[f$id]])) foto[[f$id]] <- anterior[[f$id]]
-  } else {
-    foto[[f$id]] <- sort(guardar(f$id, capas))
-  }
+  if (is.null(capas)) fallaron <- c(fallaron, f$id) else visto[[f$id]] <- capas
 }
 
 # De un indice de directorio solo interesan los archivos que el paquete podria
 # llegar a bajar. El de MIDES lista 493 entradas y 83 son zip: seguir las otras
 # 410 -xml y txt de acompanamiento- seria ruido garantizado.
-sin_indice <- character()
 for (i in indices) {
   r <- listado_del_indice(i)
   if (identical(r$estado, "sin indice")) {
@@ -167,13 +167,27 @@ for (i in indices) {
   }
   if (identical(r$estado, "sin respuesta")) {
     fallaron <- c(fallaron, i)
-    if (!is.null(anterior[[i]])) foto[[i]] <- anterior[[i]]
     next
   }
-  foto[[i]] <- sort(guardar(i, grep("\\.(zip|rar|7z)$", r$archivos, value = TRUE, ignore.case = TRUE)))
+  visto[[i]] <- grep("\\.(zip|rar|7z)$", r$archivos, value = TRUE, ignore.case = TRUE)
 }
 
-saveRDS(foto, "catalogo-capas.rds")
+# ---- La foto ----------------------------------------------------------------
+
+# La foto NO es "lo que hay publicado hoy" sino "todo lo que vimos alguna vez":
+# la union de la anterior con la de hoy. Asi ninguna lectura incompleta puede
+# sacar entradas de la foto, que es justo lo que la semana siguiente las
+# devolveria como novedad. Y de paso hace innecesario cualquier cuidado
+# especial con las fuentes que fallan o que vuelven vacias: si no aportan nada,
+# la foto queda como estaba.
+#
+# El precio es que una capa dada de baja se queda en la foto para siempre, y si
+# vuelve no se avisa. Es barato: las bajas no son lo que esto reporta, de eso ya
+# se ocupa el chequeo de capas caidas.
+foto <- list()
+for (id in union(names(anterior), names(visto))) {
+  foto[[id]] <- sort(union(anterior[[id]], visto[[id]]))
+}
 
 # ---- El diff ----------------------------------------------------------------
 
@@ -184,9 +198,9 @@ ya_la_tenemos <- function(x) sin_prefijo(x) %in% sin_prefijo(usadas)
 
 novedades <- list()
 if (!is.null(anterior)) {
-  for (id in names(foto)) {
+  for (id in names(visto)) {
     if (is.null(anterior[[id]])) next   # fuente nueva: no es novedad del organismo
-    nuevas <- setdiff(foto[[id]], anterior[[id]])
+    nuevas <- setdiff(visto[[id]], anterior[[id]])
     if (length(nuevas)) novedades[[id]] <- nuevas
   }
 }
@@ -235,6 +249,11 @@ close(con)
 # semana. Vacia cuando no hay novedades.
 estado <- unlist(lapply(names(novedades), function(id) paste0(id, "|", novedades[[id]])))
 writeLines(sort(as.character(estado)), "catalogo-capas.estado")
+
+# La foto se guarda al final a proposito. Si se guardara antes y el script se
+# rompiera armando el informe, la novedad quedaria absorbida por la foto nueva y
+# no se reportaria nunca.
+saveRDS(foto, "catalogo-capas.rds")
 
 cat(readLines("catalogo-capas.md"), sep = "\n")
 cat("\n")

--- a/.github/scripts/chequeo-capas.R
+++ b/.github/scripts/chequeo-capas.R
@@ -17,6 +17,21 @@ load("data/metadata.rda")
 # consultas WFS con outputFormat=shape-zip -o sea, se pueden acotar a una feature-
 # y 17 son archivos estaticos que pesan cientos de MB, a los que solo se les pide
 # la cabecera.
+# Lo que se comparte con catalogo-capas.R -salir a la red, leer un indice de
+# directorio- vive en comun.R. Se resuelve relativo a este archivo para que ande
+# igual corriendo desde la raiz del repo o desde otro lado.
+.comun <- function() {
+  a <- commandArgs(trailingOnly = FALSE)
+  f <- sub("^--file=", "", a[grep("^--file=", a)])
+  candidatos <- c(if (length(f)) file.path(dirname(normalizePath(f[1])), "comun.R"),
+                  file.path(".github", "scripts", "comun.R"), "comun.R")
+  hay <- candidatos[file.exists(candidatos)]
+  if (!length(hay)) stop("No encuentro comun.R; se lo busco en: ",
+                         paste(candidatos, collapse = ", "))
+  hay[1]
+}
+source(.comun())
+
 es_wfs <- function(url) grepl("request=GetFeature", url, ignore.case = TRUE)
 es_archivo <- function(url, formato) formato %in% c("zip", "zip a") && !es_wfs(url)
 
@@ -44,33 +59,6 @@ endpoint <- function(url) {
   url
 }
 
-# tope: cuantos bytes del cuerpo se leen. 64 KB alcanzan de sobra para
-# reconocer un GML, un JSON o un zip por su primer bloque, y evitan cargar una
-# capa entera en memoria. El indice de un directorio es otra cosa: el de MIDES
-# pesa 118 KB y el archivo que se busca puede estar en cualquier parte, asi que
-# ahi se pide mas.
-consultar <- function(url, solo_cabecera, tope = 65536L) {
-  cuerpo <- tempfile()
-  on.exit(unlink(cuerpo), add = TRUE)
-  args <- c("-sS", "-o", shQuote(cuerpo),
-            "-w", shQuote("GEOUY:%{http_code}:%{size_download}:%{url_effective}"),
-            "--connect-timeout", "15", "--max-time", "90", "-L",
-            "--retry", "2", "--retry-delay", "5", "--retry-all-errors")
-  if (solo_cabecera) args <- c(args, "-I")
-  salida <- suppressWarnings(system2("curl", c(args, "--", shQuote(url)),
-                                     stdout = TRUE, stderr = FALSE))
-  estado <- attr(salida, "status"); if (is.null(estado)) estado <- 0L
-  linea <- grep("^GEOUY:", salida, value = TRUE)
-  if (estado != 0L || !length(linea)) {
-    return(list(codigo = "000", bytes = 0, url = url, curl = estado, texto = ""))
-  }
-  p <- strsplit(sub("^GEOUY:", "", linea[length(linea)]), ":", fixed = TRUE)[[1]]
-  n <- suppressWarnings(min(file.info(cuerpo)$size, tope))
-  texto <- if (!is.na(n) && n > 0) readChar(cuerpo, n, useBytes = TRUE) else ""
-  list(codigo = p[1], bytes = as.numeric(p[2]),
-       url = paste(p[-(1:2)], collapse = ":"), curl = 0L, texto = texto)
-}
-
 # Los archivos estaticos de algunos servidores se regeneran: se borran y se
 # vuelven a crear, y mientras tanto devuelven 404 aunque el servicio este
 # perfecto. Nos paso con "Educacion especial", que estuvo casi veinte horas asi
@@ -82,22 +70,12 @@ consultar <- function(url, solo_cabecera, tope = 65536L) {
 # indice, asi que cuando no hay se reporta como antes.
 #
 # Ojo: uno de esos servidores contesta HTTP 200 con una pagina de error en vez
-# de 404, asi que mirar el codigo no alcanza. Se exige que el cuerpo tenga
-# varias entradas de archivo, que es lo que distingue un listado de una pagina
-# cualquiera servida con 200.
+# de 404, y otro contesta 200 con una pagina normal que no es un listado. De
+# distinguir un indice de verdad se encarga listado_del_indice(), en comun.R.
 figura_en_el_indice <- function(url) {
   archivo <- basename(sub("[?#].*", "", url))
   if (!nzchar(archivo)) return(FALSE)
-  indice <- sub("[^/]*$", "", sub("[?#].*", "", url))
-  # El indice se lee entero: el archivo buscado puede estar al final. Se pone un
-  # techo igual, para que un servidor que devuelva algo enorme no llene la
-  # memoria del runner.
-  r <- consultar(indice, FALSE, tope = 4194304L)
-  if (r$curl != 0L || !identical(r$codigo, "200")) return(FALSE)
-  listados <- regmatches(r$texto, gregexpr('href="[^"?/][^"]*"', r$texto))[[1]]
-  listados <- sub('href="', "", sub('"$', "", listados))
-  if (length(listados) < 2) return(FALSE)
-  archivo %in% listados
+  archivo %in% listado_del_indice(directorio_de(url))$archivos
 }
 
 # Un 200 no alcanza: los geoserver contestan las excepciones con codigo 200 y un

--- a/.github/scripts/comun.R
+++ b/.github/scripts/comun.R
@@ -1,0 +1,56 @@
+# Lo que comparten chequeo-capas.R y catalogo-capas.R. Son dos preguntas
+# distintas -que se rompio contra que aparecio- pero salen a la red igual, y no
+# conviene que una consulte con timeouts o reintentos distintos de la otra.
+
+# tope: cuantos bytes del cuerpo se leen. 64 KB alcanzan de sobra para reconocer
+# un GML, un JSON o un zip por su primer bloque, y evitan cargar una capa entera
+# en memoria. Un indice de directorio o un GetCapabilities son otra cosa: el
+# indice de MIDES pesa 118 KB y el GetCapabilities del IDE casi 400 KB, asi que
+# ahi hay que pedir mas.
+consultar <- function(url, solo_cabecera, tope = 65536L) {
+  cuerpo <- tempfile()
+  on.exit(unlink(cuerpo), add = TRUE)
+  args <- c("-sS", "-o", shQuote(cuerpo),
+            "-w", shQuote("GEOUY:%{http_code}:%{size_download}:%{url_effective}"),
+            "--connect-timeout", "15", "--max-time", "90", "-L",
+            "--retry", "2", "--retry-delay", "5", "--retry-all-errors")
+  if (solo_cabecera) args <- c(args, "-I")
+  salida <- suppressWarnings(system2("curl", c(args, "--", shQuote(url)),
+                                     stdout = TRUE, stderr = FALSE))
+  estado <- attr(salida, "status"); if (is.null(estado)) estado <- 0L
+  linea <- grep("^GEOUY:", salida, value = TRUE)
+  if (estado != 0L || !length(linea)) {
+    return(list(codigo = "000", bytes = 0, url = url, curl = estado, texto = ""))
+  }
+  p <- strsplit(sub("^GEOUY:", "", linea[length(linea)]), ":", fixed = TRUE)[[1]]
+  n <- suppressWarnings(min(file.info(cuerpo)$size, tope))
+  texto <- if (!is.na(n) && n > 0) readChar(cuerpo, n, useBytes = TRUE) else ""
+  list(codigo = p[1], bytes = as.numeric(p[2]),
+       url = paste(p[-(1:2)], collapse = ":"), curl = 0L, texto = texto)
+}
+
+# Un listado de directorio de Apache tiene muchos href RELATIVOS a archivos del
+# propio directorio. Las dos condiciones importan:
+#
+#  - Relativos: sit.mvot.gub.uy/shp/ contesta 200 con una pagina normal cuyos
+#    unicos href son un favicon y un enlace a otro dominio. Sin exigir que sean
+#    relativos, esa pagina pasaba por listado.
+#  - Mas de uno: hay servidores que contestan 200 con una pagina de error.
+#
+# Devuelve el estado aparte de los archivos, porque no es lo mismo que el
+# servidor no conteste -hay que reintentar- a que ese directorio simplemente no
+# publique indice, que es una propiedad estable y no un problema.
+listado_del_indice <- function(indice) {
+  r <- consultar(indice, FALSE, tope = 4194304L)
+  if (r$curl != 0L || !identical(r$codigo, "200")) {
+    return(list(estado = "sin respuesta", archivos = character()))
+  }
+  n <- regmatches(r$texto, gregexpr('href="[^"?/][^"]*"', r$texto))[[1]]
+  n <- sub('href="', "", sub('"$', "", n))
+  n <- unique(n[!grepl("://", n, fixed = TRUE)])
+  if (length(n) < 2) list(estado = "sin indice", archivos = character())
+  else list(estado = "ok", archivos = n)
+}
+
+# Directorio al que pertenece un archivo servido por URL.
+directorio_de <- function(url) sub("[^/]*$", "", sub("[?#].*", "", url))

--- a/.github/scripts/comun.R
+++ b/.github/scripts/comun.R
@@ -2,11 +2,15 @@
 # distintas -que se rompio contra que aparecio- pero salen a la red igual, y no
 # conviene que una consulte con timeouts o reintentos distintos de la otra.
 
-# tope: cuantos bytes del cuerpo se leen. 64 KB alcanzan de sobra para reconocer
-# un GML, un JSON o un zip por su primer bloque, y evitan cargar una capa entera
-# en memoria. Un indice de directorio o un GetCapabilities son otra cosa: el
-# indice de MIDES pesa 118 KB y el GetCapabilities del IDE casi 400 KB, asi que
-# ahi hay que pedir mas.
+# tope: cuantos bytes del cuerpo se LEEN A MEMORIA. Ojo con lo que no hace:
+# curl baja el cuerpo entero a un archivo temporal igual, y recien despues se
+# lee el principio. Lo que acota la descarga en si es otra cosa -maxFeatures=1
+# en las consultas WFS, y pedir solo la cabecera en los archivos estaticos-.
+#
+# 64 KB alcanzan de sobra para reconocer un GML, un JSON o un zip por su primer
+# bloque. Un indice de directorio o un GetCapabilities son otra cosa: el indice
+# de MIDES pesa 118 KB y el GetCapabilities del IDE casi 400 KB, asi que ahi hay
+# que pedir mas.
 consultar <- function(url, solo_cabecera, tope = 65536L) {
   cuerpo <- tempfile()
   on.exit(unlink(cuerpo), add = TRUE)

--- a/.github/workflows/chequeo-capas.yaml
+++ b/.github/workflows/chequeo-capas.yaml
@@ -126,8 +126,12 @@ jobs:
           fi
           # Si la corrida anterior es de antes de que existiera el catálogo, no
           # tiene ese artifact y no pasa nada: se guarda la foto de hoy.
-          gh run download "$previa" --name catalogo-capas --dir . \
-            || echo "La corrida $previa no dejó foto del catálogo."
+          if ! gh run download "$previa" --name catalogo-capas --dir . 2>/dev/null; then
+            # No distinguimos "todavía no existía" de un error de red o de la API,
+            # pero sí queremos verlo: sin foto anterior, la corrida arranca de
+            # cero y lo que haya aparecido en el medio no se reporta.
+            echo "::warning::No se pudo traer la foto del catálogo de la corrida $previa; esta corrida arranca de cero."
+          fi
 
       - name: Mirar qué publican los organismos
         id: catalogo
@@ -139,6 +143,12 @@ jobs:
           rc=$?
           set -e
           echo "codigo=$rc" >> "$GITHUB_OUTPUT"
+          # 0 es sin novedades y 2 es que hay algo nuevo. Cualquier otro codigo
+          # es que el script se rompio, y eso hay que verlo: un catalogo roto en
+          # silencio se ve igual que un catalogo sin novedades, para siempre.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "::warning::El chequeo del catálogo terminó con código $rc; revisá el log de este paso."
+          fi
 
       - name: Guardar la foto del catálogo
         if: always()

--- a/.github/workflows/chequeo-capas.yaml
+++ b/.github/workflows/chequeo-capas.yaml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
   issues: write
+  # Para bajar el artifact de la corrida anterior, que es donde vive la foto del
+  # catalogo. actions/cache seria lo natural pero no sirve: GitHub descarta las
+  # entradas que no se tocan en 7 dias y este workflow corre justo cada 7.
+  actions: read
 
 # El cron y un disparo manual a la vez podrían abrir dos issues.
 concurrency:
@@ -103,3 +107,70 @@ jobs:
             gh issue edit "$numero" --add-label "recuperacion-pendiente"
             gh issue comment "$numero" --body "Todas las capas respondieron en este chequeo. Se cierra si el próximo también sale limpio."
           fi
+
+      # ---- Segunda parte: que publican los organismos --------------------------
+      # Va despues del chequeo y con continue-on-error, para que un problema del
+      # catalogo nunca impida enterarse de una capa caida, que es lo urgente.
+
+      - name: Traer la foto del catálogo de la corrida anterior
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          previa=$(gh run list --workflow chequeo-capas.yaml --status success \
+                     --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+          if [ -z "$previa" ]; then
+            echo "No hay corrida anterior exitosa; el catálogo arranca de cero."
+            exit 0
+          fi
+          # Si la corrida anterior es de antes de que existiera el catálogo, no
+          # tiene ese artifact y no pasa nada: se guarda la foto de hoy.
+          gh run download "$previa" --name catalogo-capas --dir . \
+            || echo "La corrida $previa no dejó foto del catálogo."
+
+      - name: Mirar qué publican los organismos
+        id: catalogo
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          Rscript .github/scripts/catalogo-capas.R
+          rc=$?
+          set -e
+          echo "codigo=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Guardar la foto del catálogo
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: catalogo-capas
+          retention-days: 30
+          if-no-files-found: ignore
+          path: |
+            catalogo-capas.md
+            catalogo-capas.rds
+            catalogo-capas.estado
+
+      # Un issue aparte del de capas caídas: son cosas distintas y se resuelven
+      # distinto. Este no se cierra solo; lo cierra quien decida si la capa nueva
+      # entra al paquete o no.
+      - name: Avisar si apareció algo nuevo
+        if: steps.catalogo.outputs.codigo == '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          huella=$(sha256sum catalogo-capas.estado | cut -d' ' -f1)
+          if gh issue list --label "capas-nuevas" --state open --limit 20 --json body \
+               --jq '.[].body' | grep -qF "huella:$huella"; then
+            echo "Ya hay un issue abierto con esta misma novedad."
+            exit 0
+          fi
+          cuerpo=$(mktemp)
+          cat catalogo-capas.md > "$cuerpo"
+          printf '\n<!-- huella:%s -->\n' "$huella" >> "$cuerpo"
+          gh label create "capas-nuevas" --color 1D76DB \
+            --description "Los organismos publicaron capas que el paquete no tiene" 2>/dev/null || true
+          gh issue create --title "Capas nuevas en los servicios ($(date -u +%Y-%m-%d))" \
+            --label "capas-nuevas" --body-file "$cuerpo"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ geouy*.tgz
 chequeo-capas.md
 chequeo-capas.rds
 chequeo-capas.estado
+catalogo-capas.md
+catalogo-capas.rds
+catalogo-capas.estado

--- a/news/59-catalogo-capas.md
+++ b/news/59-catalogo-capas.md
@@ -1,0 +1,6 @@
+* The weekly check now also looks at what the organisms publish, not only at
+  whether what the package already uses still answers. It takes a snapshot of
+  the catalogues the package draws from -the WFS workspaces and the directory
+  index of the static files- and reports what appeared since the previous run.
+  It deliberately does not report everything published that the package does
+  not use: that would be seventy-odd entries every single week.


### PR DESCRIPTION
Es la parte 2 del #50, la que te interesaba: hoy el chequeo semanal sólo detecta
que **lo nuestro** se rompa, y esto detecta que **ellos** sacaron algo nuevo. En
`/2shp/out/` del MIDES hay 83 zip y el paquete usa 7.

Lo que **no** hace, que es lo que decide si sirve o no: no reporta «lo que ellos
tienen y nosotros no». Eso son setenta y pico de faltantes todas las semanas y
muere a la primera. Reporta el diff contra la corrida anterior: lo que no estaba
y ahora está.

## Qué mira

Los workspaces que el paquete usa, no los servidores enteros. Los medí:

| Servidor | Publica | Usa el paquete |
|---|---|---|
| IDE, `geoserver-vectorial` entero | 552 | 26 |
| MTOP, `geoserver` entero | 267 | 5 |
| MIDES, `geoserver` entero | 135 | 23 |

Entre catastro, cartografía nacional y mantenimiento vial, una capa nueva ahí no
tiene nada que ver con lo que hace el paquete. Acotado a los workspaces nuestros
son 207, y una capa nueva en `INECenso` sí es del mismo tema que las que ya
traemos. La foto de hoy son **290 entradas en 13 catálogos**.

De ahí sale un dato que quizá te sirva aparte: los workspaces censales están
cubiertos al 100% (`INECenso` 5 de 5, `INECenso2011` 3 de 3). El margen está en
`IDE` del MIDES (119 publicadas, 9 usadas), en `INE_NO_SEGURO` (16 sin usar,
entre ellas la hidrografía y `centros_ceip`) y en los zip.

## Dónde vive la foto

En el artifact de la corrida anterior, que se baja con `gh run download`.
`actions/cache` parecía lo natural pero no sirve: GitHub descarta las entradas
que no se tocan en 7 días y esto corre justo cada 7. La retención de los
artifacts es de 30, así que sobra. Por eso el workflow suma `actions: read`.

## Lo que más cuidé: no generar ruido

La foto no es «lo que hay publicado hoy» sino **todo lo que vimos alguna vez**,
la unión de la anterior con la de hoy. Suena raro pero es lo que hace que esto
no se llene de falsas alarmas: una lectura incompleta -un `GetCapabilities`
truncado que igual trae algunos `<Name>`, un índice servido a medias- no puede
sacar entradas de la foto, y por lo tanto no puede devolverlas como novedad la
semana siguiente. El precio es que una capa dada de baja se queda en la foto y
si vuelve no se avisa; barato, porque las bajas ya las mira el otro chequeo.

Además, una fuente que **no estaba** en la foto anterior no se reporta: es nueva
para nosotros, no del organismo.

## Cosas que aparecieron probándolo

Ninguna se veía leyendo el código:

- El metadata escribe el mismo servidor con `:443` y sin, y el mismo workspace
  por ruta y por prefijo del typeName. Sin normalizarlo consultaba **tres
  catálogos dos veces** y guardaba 250 entradas repetidas.
- El ArcGIS del IGM escribe `<wfs:Name>` y los geoserver `<Name>` pelado, así
  que **los tres servicios del IGM quedaban afuera**.
- Con `version=2.0.0` el geoserver del MIDES contesta una excepción para **todo
  el workspace**, porque una capa suelta —`aulas_comunitarias`— tiene el esquema
  roto. Va con 1.1.0.
- `sit.mvot.gub.uy/shp/` contesta 200 con una página normal cuyos únicos enlaces
  son un favicon y otro dominio, y **pasaba por índice de directorio**. Ahora se
  exige que los enlaces sean relativos.
- Si el filtro por workspace no dejaba nada, el código guardaba **el servidor
  entero** bajo el id del workspace. Parecía un resguardo y era la rama
  peligrosa.

## Sobre el `comun.R`

Salir a la red y leer un índice de directorio es lo que los dos chequeos hacen
igual, y quedaba duplicado. `consultar()` se mudó **sin tocarle una línea**.

Como toqué el chequeo semanal, lo corrí entero en las dos versiones para
comparar: **mismo veredicto en las 90 capas**, mismo conteo (71 de 90 — siguen
caídas las 19 de Ambiente del #30), misma salida. Y la lectura del índice, vieja
contra nueva, sobre los 15 archivos estáticos del metadata: **cero diferencias**.

## Verificación

- Le saqué tres entradas a la foto (`liceos.zip`, `IDE:Hospitales` y
  `Millon:Ciudades`): reporta esas tres y sólo esas, con la marca «el paquete ya
  la usa» en las dos que usamos.
- Metí una entrada fantasma que el servidor no publica: **no** se reporta y
  **sobrevive** en la foto, que es la garantía nueva.
- Filtro por un workspace inexistente: da lectura fallida en vez de las 135
  capas del servidor.

Todo el bloque nuevo va con `continue-on-error`, así que un problema del
catálogo nunca puede tapar una capa caída, que es lo urgente. Y hay un
`::warning::` si el script sale con un código raro: un catálogo roto en silencio
se ve igual que un catálogo sin novedades, para siempre.

Dos cosas que miré y decidí **no** cambiar, por si te las preguntás: el script
descarta los parámetros de la URL al armar el `GetCapabilities`, lo que rompería
un servidor que necesite algo como `map=`, pero ninguno de los nuestros lo usa;
y el parser de índices sólo entiende el formato que sirve Apache, que es el
único índice abierto que tenemos.
