### PR TITLE
where_uy(d = "cod") ahora consulta las capas cuyo código es de texto

### DIFF
--- a/R/where_uy.R
+++ b/R/where_uy.R
@@ -2,7 +2,10 @@
 #' @family service
 #' @param c Define the geometries to consult: may be: "Departamentos", "Secciones", "Zonas", etc. View(metadata) for details.
 #' @param d A vector who determines the variables to be consult, with two options: "cod" or "name". Default "cod".
-#' @param e A vector who determines the ids or names to identify.
+#' @param e A vector who determines the ids or names to identify. It is matched
+#'   against the column the metadata declares, using that column's own type: a
+#'   numeric code is compared as a number and a textual one, such as `gml_id` or
+#'   the INE codes like "UY-MO", as text.
 #' @param crs Define the Coordinate Reference Systems you want the output, default 32721
 #' @keywords IDE MIDES INE
 #' @return sf object with the geometries of the d ids
@@ -14,18 +17,77 @@
 #'}
 
 where_uy <- function(c = "Localidades pg", d = "cod", e, crs = 32721) {
-  if (is.character(e) & d %in% "cod") {
-    e <- as.numeric(e)
-    if (is.na(e)) stop(glue::glue("The elements in {e} are all character, and for being {d} may be numeric"))
+  # Sin try() alrededor de los stop(). Un try() atrapa el error que el propio
+  # codigo acaba de levantar, la funcion sigue como si nada y el usuario termina
+  # viendo un error de mas abajo que no habla del problema real.
+  if (length(d) != 1 || !d %in% c("cod", "name")) {
+    stop("The argument d may be either \"cod\" or \"name\".")
   }
-  if (is.numeric(e) & d %in% "name") stop(glue::glue("The elements in {e} are numeric, and for being {d} may be character"))  
-  md <- geouy::metadata 
-  try(if (sum(!c %in% md$capa) > 0) stop("The name of the geometry you will load is not correct. Verify in the metadata file"))
-  md <- md[md$capa %in% c,]
-  a <- ifelse(d %in% "cod", md$cod, md$name)
-  try(if(is.na(a)) stop(glue::glue("The layer {c} have not still a variable {d}, Please make an issue to suggest changes.")))
-  y <- geouy::load_geouy(c, crs = crs) %>% dplyr::filter(dplyr::pull(., a) %in% e)
-  if(nrow(y) == 0) stop("Sorry, your consult has not matches, verify ids")
-  if(nrow(y) < length(e)) warning(glue::glue("Your consult has less matches than elements in {e}, verify filter"))
-  return(y)
+  if (length(c) != 1) {
+    stop("You may consult one layer at a time in c.")
+  }
+  if (missing(e) || length(e) == 0) {
+    stop("You may give at least one id in e.")
+  }
+
+  md <- geouy::metadata
+  if (!c %in% md$capa) {
+    stop("The name of the geometry you will load is not correct. Verify in the metadata file")
+  }
+  md <- md[md$capa %in% c, ]
+  a <- if (identical(d, "cod")) md$cod else md$name
+  if (is.na(a)) {
+    stop(glue::glue("The layer {c} have not still a variable {d}, Please make an issue to suggest changes."))
+  }
+
+  y <- geouy::load_geouy(c, crs = crs)
+  if (!a %in% names(y)) {
+    stop(glue::glue("The metadata declares {a} as the {d} of {c}, ",
+                    "but the layer does not bring that column."))
+  }
+  columna <- dplyr::pull(y, a)
+
+  # Se compara en el tipo de la columna en vez de forzar todo a numero. Antes,
+  # con d = "cod" se hacia as.numeric(e) siempre, y eso dejaba afuera las capas
+  # cuyo codigo es de texto -gml_id, globalid, o los codigos del INE tipo
+  # "UY-MO"-, que son diez de las sesenta y cuatro que declaran cod: ahi la
+  # consulta era imposible de las dos formas, con numero porque la columna nunca
+  # matchea y con texto porque la coercion lo convertia en NA.
+  if (is.numeric(columna) && is.character(e)) {
+    numeros <- suppressWarnings(as.numeric(e))
+    if (anyNA(numeros)) {
+      stop(glue::glue("The {d} of {c} is numeric, and these elements are not ",
+                      "numbers: {enumerar(e[is.na(numeros)])}"))
+    }
+    e <- numeros
+  } else if (!is.numeric(columna)) {
+    columna <- as.character(columna)
+    e <- as.character(e)
+  }
+
+  y <- y[columna %in% e, ]
+
+  # El mensaje de "no hay coincidencias" dice contra que columna se comparo y
+  # que aspecto tienen sus valores. Antes decia "verify ids" a secas, que sonaba
+  # a que el id del usuario estaba mal incluso cuando la consulta era imposible.
+  if (nrow(y) == 0) {
+    stop(glue::glue("Sorry, your consult has not matches in {a}, the {d} of {c}. ",
+                    "That column holds values like {enumerar(unique(columna), 3)}"))
+  }
+  faltan <- setdiff(e, columna)
+  if (length(faltan) > 0) {
+    warning(glue::glue("These elements have no match in {a}: {enumerar(faltan)}"))
+  }
+  y
+}
+
+# Los mensajes tienen que quedar acotados: stop() corta a 8190 caracteres, y una
+# consulta con cientos de ids llegaria a eso sin problema.
+enumerar <- function(x, tope = 5) {
+  x <- as.character(x)
+  if (length(x) > tope) {
+    paste0(paste(x[seq_len(tope)], collapse = ", "), " and ", length(x) - tope, " more")
+  } else {
+    paste(x, collapse = ", ")
+  }
 }

--- a/man/where_uy.Rd
+++ b/man/where_uy.Rd
@@ -11,7 +11,10 @@ where_uy(c = "Localidades pg", d = "cod", e, crs = 32721)
 
 \item{d}{A vector who determines the variables to be consult, with two options: "cod" or "name". Default "cod".}
 
-\item{e}{A vector who determines the ids or names to identify.}
+\item{e}{A vector who determines the ids or names to identify. It is matched
+against the column the metadata declares, using that column's own type: a
+numeric code is compared as a number and a textual one, such as `gml_id` or
+the INE codes like "UY-MO", as text.}
 
 \item{crs}{Define the Coordinate Reference Systems you want the output, default 32721}
 }

--- a/news/60-where-uy-cod-texto.md
+++ b/news/60-where-uy-cod-texto.md
@@ -1,0 +1,12 @@
+* `where_uy(d = "cod")` can now query the layers whose code is textual. It used
+  to run the ids through `as.numeric()` whenever `d = "cod"`, so a layer that
+  declares `gml_id` or `globalid` as its code -ten of the sixty-four that
+  declare one- could not be queried at all: a number never matched the column,
+  and a text id was turned into `NA` before it got there. The ids are now
+  compared using the type of the column itself.
+* `where_uy()` says which column it compared against and what its values look
+  like when nothing matches, instead of only "verify ids", which read as if the
+  id were wrong even when the query could not have worked.
+* `where_uy()` no longer stops with `the condition has length > 1` when several
+  non-numeric ids are given at once, and the warning about ids that found no
+  match now names them instead of interpolating the whole vector.

--- a/tests/testthat/test-where_uy.R
+++ b/tests/testthat/test-where_uy.R
@@ -23,8 +23,60 @@ test_that("where_uy filtra por codigo y por nombre", {
 
   # Un codigo que no existe no devuelve nada, y lo dice.
   expect_error(where_uy(c = "Localidades pg", d = "cod", e = inexistente))
+})
 
-  # Los tipos tienen que corresponderse con lo que se pide.
-  expect_warning(expect_error(where_uy(c = "Localidades pg", d = "cod", e = "c")))
-  expect_error(where_uy(c = "Localidades pg", d = "name", e = 1))
+test_that("where_uy consulta un cod numerico venga como numero o como texto", {
+  skip_if_offline()
+
+  loc <- load_geouy("Localidades pg")
+  cod <- loc$CODLOC[[1]]
+
+  # La columna manda: si es numerica, un id de texto que sea un numero sirve.
+  expect_equal(nrow(where_uy(c = "Localidades pg", d = "cod", e = as.character(cod))), 1)
+
+  # Y si no es un numero, el error dice cual de los elementos no lo es, en vez
+  # de convertirlo a NA y hablar de NA.
+  expect_error(where_uy(c = "Localidades pg", d = "cod", e = "c"), "not numbers")
+})
+
+test_that("where_uy consulta las capas cuyo cod es de texto", {
+  skip_if_offline()
+
+  # Diez de las sesenta y cuatro capas que declaran cod declaran uno de texto
+  # -gml_id o globalid-, y ahi la consulta era imposible: con un numero la
+  # columna nunca matcheaba, y con texto la coercion a numero lo volvia NA.
+  # Se toma un id real de la propia capa, por lo mismo que arriba.
+  peajes <- load_geouy("Peajes")
+  id <- peajes$gml_id[[1]]
+
+  uno <- where_uy(c = "Peajes", d = "cod", e = id)
+  expect_s3_class(uno, "sf")
+  expect_equal(nrow(uno), 1)
+  expect_equal(uno$gml_id[[1]], id)
+
+  expect_equal(nrow(where_uy(c = "Peajes", d = "cod", e = peajes$gml_id[1:3])), 3)
+
+  # El aviso nombra el que falto, no el vector entero.
+  expect_warning(where_uy(c = "Peajes", d = "cod", e = c(id, "NO_EXISTE")), "NO_EXISTE")
+})
+
+test_that("where_uy avisa cuando la consulta no puede funcionar", {
+  skip_if_offline()
+
+  # El mensaje de "no hay coincidencias" dice contra que columna se comparo y
+  # que aspecto tienen sus valores. Antes decia "verify ids" a secas, que sonaba
+  # a que el id estaba mal incluso cuando la consulta era imposible.
+  expect_error(where_uy(c = "Peajes", d = "cod", e = 1), "gml_id")
+
+  # Una capa sin cod declarado tiene que decir eso, y no reventar mas abajo con
+  # un error de tidyselect.
+  expect_error(where_uy(c = "Educacion especial", d = "cod", e = 1),
+               "have not still a variable")
+})
+
+test_that("where_uy valida sus argumentos antes de salir a la red", {
+  expect_error(where_uy(c = "Peajes", d = "otra cosa", e = 1), "cod")
+  expect_error(where_uy(c = c("Peajes", "Rutas"), d = "cod", e = 1), "one layer")
+  expect_error(where_uy(c = "Peajes", d = "cod", e = character(0)), "at least one")
+  expect_error(where_uy(c = "No existe esta capa", d = "cod", e = 1), "not correct")
 })


### PR DESCRIPTION
Cierra el #28, por donde dijiste: sacarle a `where_uy()` la exigencia de que el
`cod` sea numérico.

## Lo que pasaba

La función hacía `as.numeric(e)` siempre que `d = "cod"`, así que la columna
declarada en `metadata$cod` tenía que ser numérica para que la consulta pudiera
funcionar. Son **diez de las sesenta y cuatro capas** que declaran `cod` las que
declaran uno de texto —nueve con `gml_id` y `Limites departamentales` con
`globalid`— y ahí la consulta era imposible de las dos formas:

```r
where_uy("Peajes", d = "cod", e = 1)
#> Error: Sorry, your consult has not matches, verify ids
where_uy("Peajes", d = "cod", e = "peajes.1")
#> Error: The elements in NA are all character, and for being cod may be numeric
```

Mirá el segundo: dice «NA» porque interpola el `e` que él mismo acababa de
convertir. Y el primero es el peor, porque le dice al usuario que su id está mal
cuando esa columna nunca iba a matchear un número.

Reproduciéndolo apareció un tercero que no estaba en el issue:

```r
where_uy("Peajes", d = "cod", e = c("a", "b"))
#> Error: the condition has length > 1
```

Eso no es un mensaje del paquete: es `if (is.na(e))` sobre un vector, que R
rechaza desde la 4.2.

## Lo que hace ahora

Compara **en el tipo de la columna**. Si es numérica y vienen ids de texto, los
convierte y avisa cuál no es un número; si es de texto, compara como texto.

```r
where_uy("Peajes", d = "cod", e = "peajes.1")
#> 1 fila
where_uy("Limites departamentales", d = "cod", e = "{9096DC4E-3C59-4052-91EF-29A60DEA9C9D}")
#> 1 fila, ARTIGAS
```

Tres cosas más, todas del mismo lugar:

- **El mensaje de «no hay coincidencias» dice contra qué columna se comparó y
  qué aspecto tienen sus valores**, que es lo que pedías al final del issue.
  Funciona: escribiendo las pruebas puse `Peajes.1` con mayúscula y el error me
  contestó *«That column holds values like peajes.1, peajes.2, peajes.3 and 15
  more»*, o sea que me corrigió el vector de prueba.
- **El aviso de ids sin coincidencia nombra los que faltaron.** Antes se armaba
  con `glue()` sobre el vector entero, que es vectorizado: la misma forma que
  armó el «bad error message» que nos archivó de CRAN. Va acotado a cinco,
  porque `stop()` trunca a 8190 caracteres.
- **`d` se valida.** Antes, cualquier cosa que no fuera `"cod"` caía silenciosamente
  en consultar por `name`.

## Una decisión que quiero que mires

Saqué los dos `try()` que envolvían `stop()` **dentro de esta función**. Sin eso,
el mensaje «esta capa no tiene `cod`» no llegaba nunca: el `try` lo atrapaba, la
función seguía y el usuario recibía un error de internals de tidyselect de más
abajo. Como el issue pide distinguir «no encontré ese id» de «esta capa no se
puede consultar así», sin sacarlos no se podía cumplir.

Es el patrón del #15, pero acá lo toqué **sólo en `where_uy()`**. El resto del
paquete queda para cuando decidas el #15.

## Verificación

Los ids salen de la propia capa y no de un valor escrito a mano, por lo mismo
que arreglamos en los tests del #43: un valor puntual de un servicio ajeno queda
viejo sin que nadie se entere.

- `Peajes` por `gml_id`: 1 fila con un id, 3 con tres, y con uno real más uno
  inventado devuelve la fila y avisa nombrando el que faltó.
- `Limites departamentales` por `globalid`: 1 fila, ARTIGAS.
- Controles de lo que ya andaba: `Localidades pg` por `cod` numérico sigue dando
  2 filas, y también si los ids vienen como texto (`c("1020","2020")`); con
  `"hola"` el error dice qué elemento no es un número.
- Suite completa: **0 fallos**. El test de `where_uy` quedó en cinco bloques que
  cubren el contrato nuevo.

Aparte: mientras probaba, el IGM falló **1 de cada 3 veces**, que es el #27 en
vivo.
